### PR TITLE
Use VAR=value to set implicit variables in Makefile

### DIFF
--- a/nolibc/Makefile
+++ b/nolibc/Makefile
@@ -5,7 +5,7 @@ ifeq ($(SYSDEP_OBJS),)
     $(error SYSDEP_OBJS not set)
 endif
 
-CC?=cc
+CC=cc
 CFLAGS=-O2 -std=c99 -Wall -Wno-parentheses -Werror
 CFLAGS+=$(FREESTANDING_CFLAGS)
 


### PR DESCRIPTION
VAR?=value does not do what we thought it did.