### PR TITLE
no str stubs anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,9 @@ build/ocaml/otherlibs/libotherlibs.a: build/ocaml/config/Makefile
 	$(MAKE) -C build/ocaml/otherlibs/bigarray \
 	    CFLAGS="$(FREESTANDING_CFLAGS) -I../../byterun" \
 	    bigarray_stubs.o mmap_unix.o
-	$(MAKE) -C build/ocaml/otherlibs/str \
-	    CFLAGS="$(FREESTANDING_CFLAGS) -I../../byterun" \
-	    strstubs.o
 	$(AR) rcs $@ \
 	    build/ocaml/otherlibs/bigarray/bigarray_stubs.o \
-	    build/ocaml/otherlibs/bigarray/mmap_unix.o \
-	    build/ocaml/otherlibs/str/strstubs.o
+	    build/ocaml/otherlibs/bigarray/mmap_unix.o
 
 build/nolibc/Makefile:
 	mkdir -p build


### PR DESCRIPTION
The Str module of the OCaml stdlib is a pretty bad (imperative, stateful)
regular expression implementation using C code which is not very nice.

There are better solutions (like re if you really need regular expressions, or
astring if you only need basic string splitting etc.).