### PR TITLE
Add support for solo5-kernel-muen

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -4,17 +4,18 @@ export PKG_CONFIG_PATH=$(opam config var prefix)/lib/pkgconfig
 pkg_exists() {
     pkg-config --exists "$@"
 }
-if pkg_exists solo5-kernel-ukvm solo5-kernel-virtio; then
+if pkg_exists solo5-kernel-ukvm solo5-kernel-virtio solo5-kernel-muen; then
     echo "ERROR: Conflicting packages." 1>&2
-    echo "ERROR: Only one of solo5-kernel-ukvm, solo5-kernel-virtio can be installed." 1>&2
+    echo "ERROR: Only one of solo5-kernel-ukvm, solo5-kernel-virtio, solo5-kernel-muen can be installed." 1>&2
     exit 1
 fi
 PKG_CONFIG_DEPS=
 pkg_exists solo5-kernel-ukvm && PKG_CONFIG_DEPS=solo5-kernel-ukvm
+pkg_exists solo5-kernel-muen && PKG_CONFIG_DEPS=solo5-kernel-muen
 pkg_exists solo5-kernel-virtio && PKG_CONFIG_DEPS=solo5-kernel-virtio
 if [ -z "${PKG_CONFIG_DEPS}" ]; then
     echo "ERROR: No supported kernel package found." 1>&2
-    echo "ERROR: solo5-kernel-ukvm or solo5-kernel-virtio must be installed." 1>&2
+    echo "ERROR: solo5-kernel-ukvm, solo5-kernel-virtio or solo5-kernel-muen must be installed." 1>&2
     exit 1
 fi
 

--- a/opam
+++ b/opam
@@ -13,7 +13,7 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" | "solo5-kernel-virtio")
+  ("solo5-kernel-ukvm" | "solo5-kernel-virtio" | "solo5-kernel-muen")
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}


### PR DESCRIPTION
With the merge of Solo5/solo5#190, solo5-kernel-muen can be used to satisfy the Solo5 dependency of ocaml-freestanding.