### PR TITLE
provide uint_max, shrt_max, shrt_min, and ushrt_max, needed by newer gmp

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -23,8 +23,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The files ctype.c, fprintf.c, memchr.c, memcmp.c, memcpy.c, memmove.c,
 memset.c, printf.c, snprintf.c, stpncpy.c, strchr.c, strchrnul.c, strcmp.c,
-strncpy.c, strlen.c, vfprintf.c, vsnprintf.c in the nolibc/ directory are
-derived from musl libc, licensed under the following standard MIT license:
+strncpy.c, strlen.c, strstr.c, vfprintf.c, vsnprintf.c in the nolibc/ directory
+are derived from musl libc, licensed under the following standard MIT license:
 
 Copyright © 2005-2014 Rich Felker, et al.
 

--- a/nolibc/Makefile
+++ b/nolibc/Makefile
@@ -13,6 +13,7 @@ OBJS=ctype.o \
      dtoa.o \
      memchr.o memcmp.o memcpy.o memmove.o memset.o \
      strcmp.o strlen.o strtol.o strchr.o strchrnul.o strncpy.o stpncpy.o \
+     strstr.o \
      stubs.o \
      vfprintf.o vsnprintf.o snprintf.o fprintf.o printf.o
 

--- a/nolibc/include/limits.h
+++ b/nolibc/include/limits.h
@@ -1,8 +1,12 @@
 #ifndef _LIMITS_H
 #define _LIMITS_H
 
-#define INT_MAX  0x7fffffff
-#define INT_MIN  (-1-0x7fffffff)
+#define INT_MAX   0x7fffffff
+#define INT_MIN   (-1-0x7fffffff)
+#define UINT_MAX  0xffffffffU
+#define SHRT_MAX  0x7fff
+#define SHRT_MIN  (-1-0x7fff)
+#define USHRT_MAX 0xffff
 #if defined(__x86_64__) || defined(__aarch64__)
 #define LONG_MAX  0x7fffffffffffffffL
 #define LLONG_MAX  0x7fffffffffffffffLL

--- a/nolibc/include/string.h
+++ b/nolibc/include/string.h
@@ -17,5 +17,6 @@ char *strerror(int);
  */
 char *strncpy(char *, const char *, size_t);
 char *strchr(const char *, int);
+char *strstr(const char *, const char *);
 
 #endif

--- a/nolibc/strstr.c
+++ b/nolibc/strstr.c
@@ -1,0 +1,155 @@
+#include <string.h>
+#include <stdint.h>
+
+static char *twobyte_strstr(const unsigned char *h, const unsigned char *n)
+{
+	uint16_t nw = n[0]<<8 | n[1], hw = h[0]<<8 | h[1];
+	for (h++; *h && hw != nw; hw = hw<<8 | *++h);
+	return *h ? (char *)h-1 : 0;
+}
+
+static char *threebyte_strstr(const unsigned char *h, const unsigned char *n)
+{
+	uint32_t nw = n[0]<<24 | n[1]<<16 | n[2]<<8;
+	uint32_t hw = h[0]<<24 | h[1]<<16 | h[2]<<8;
+	for (h+=2; *h && hw != nw; hw = (hw|*++h)<<8);
+	return *h ? (char *)h-2 : 0;
+}
+
+static char *fourbyte_strstr(const unsigned char *h, const unsigned char *n)
+{
+	uint32_t nw = n[0]<<24 | n[1]<<16 | n[2]<<8 | n[3];
+	uint32_t hw = h[0]<<24 | h[1]<<16 | h[2]<<8 | h[3];
+	for (h+=3; *h && hw != nw; hw = hw<<8 | *++h);
+	return *h ? (char *)h-3 : 0;
+}
+
+#define MAX(a,b) ((a)>(b)?(a):(b))
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+#define BITOP(a,b,op) \
+ ((a)[(size_t)(b)/(8*sizeof *(a))] op (size_t)1<<((size_t)(b)%(8*sizeof *(a))))
+
+static char *twoway_strstr(const unsigned char *h, const unsigned char *n)
+{
+	const unsigned char *z;
+	size_t l, ip, jp, k, p, ms, p0, mem, mem0;
+	size_t byteset[32 / sizeof(size_t)] = { 0 };
+	size_t shift[256];
+
+	/* Computing length of needle and fill shift table */
+	for (l=0; n[l] && h[l]; l++)
+		BITOP(byteset, n[l], |=), shift[n[l]] = l+1;
+	if (n[l]) return 0; /* hit the end of h */
+
+	/* Compute maximal suffix */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] > n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	ms = ip;
+	p0 = p;
+
+	/* And with the opposite comparison */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] < n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	if (ip+1 > ms+1) ms = ip;
+	else p = p0;
+
+	/* Periodic needle? */
+	if (memcmp(n, n+p, ms+1)) {
+		mem0 = 0;
+		p = MAX(ms, l-ms-1) + 1;
+	} else mem0 = l-p;
+	mem = 0;
+
+	/* Initialize incremental end-of-haystack pointer */
+	z = h;
+
+	/* Search loop */
+	for (;;) {
+		/* Update incremental end-of-haystack pointer */
+		if (z-h < l) {
+			/* Fast estimate for MIN(l,63) */
+			size_t grow = l | 63;
+			const unsigned char *z2 = memchr(z, 0, grow);
+			if (z2) {
+				z = z2;
+				if (z-h < l) return 0;
+			} else z += grow;
+		}
+
+		/* Check last byte first; advance by shift on mismatch */
+		if (BITOP(byteset, h[l-1], &)) {
+			k = l-shift[h[l-1]];
+			//printf("adv by %zu (on %c) at [%s] (%zu;l=%zu)\n", k, h[l-1], h, shift[h[l-1]], l);
+			if (k) {
+				if (mem0 && mem && k < p) k = l-p;
+				h += k;
+				mem = 0;
+				continue;
+			}
+		} else {
+			h += l;
+			mem = 0;
+			continue;
+		}
+
+		/* Compare right half */
+		for (k=MAX(ms+1,mem); n[k] && n[k] == h[k]; k++);
+		if (n[k]) {
+			h += k-ms;
+			mem = 0;
+			continue;
+		}
+		/* Compare left half */
+		for (k=ms+1; k>mem && n[k-1] == h[k-1]; k--);
+		if (k <= mem) return (char *)h;
+		h += p;
+		mem = mem0;
+	}
+}
+
+char *strstr(const char *h, const char *n)
+{
+	/* Return immediately on empty needle */
+	if (!n[0]) return (char *)h;
+
+	/* Use faster algorithms for short needles */
+	h = strchr(h, *n);
+	if (!h || !n[1]) return (char *)h;
+	if (!h[1]) return 0;
+	if (!n[2]) return twobyte_strstr((void *)h, (void *)n);
+	if (!h[2]) return 0;
+	if (!n[3]) return threebyte_strstr((void *)h, (void *)n);
+	if (!h[3]) return 0;
+	if (!n[4]) return fourbyte_strstr((void *)h, (void *)n);
+
+	return twoway_strstr((void *)h, (void *)n);
+}


### PR DESCRIPTION
my initial goal was to upgrade zarith-freestanding to the latest zarith release (1.6).

while digging down the rabbit hole, I discovered that we are still using a gmp 6.0.0a, where the newest is 6.1.2 which has several issues fixed (excerpt from https://gmplib.org/gmp6.1.html):
- Work around faulty cpuid on some recent Intel chips (this allows GMP to run on Skylake Pentiums). 
- Speedup for Intel Broadwell and Skylake through assembly code making use of new ADX instructions.

Turns out, newer gmp needs some defines: `UINT_MAX`, `SHRT_MAX`, `SHRT_MIN`, `USHRT_MAX`; which are added in this PR.  Once this is fine to merge, we'll need a new ocaml-freestanding release to do a new gmp-freestanding release in opam-repository.
Newer gmp additionally need `strstr`, which I added from musl.