### PR TITLE
Support OCaml 4.06.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
     global:
         - TESTS=false
     matrix:
+        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-ukvm"
+        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-virtio"
         - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-kernel-ukvm"
         - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-kernel-virtio"
         - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-ukvm"

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,13 @@ build/ocaml/Makefile:
 	cp -r `ocamlfind query ocaml-src` build/ocaml
 
 build/ocaml/config/Makefile: build/ocaml/Makefile
+ifeq ($(OCAML_NEW_MAKEFILES),yes)
+	cp config/s.h build/ocaml/byterun/caml/s.h
+	cp config/m.$(BUILD_ARCH).h build/ocaml/byterun/caml/m.h
+else
 	cp config/s.h build/ocaml/config/s.h
 	cp config/m.$(BUILD_ARCH).h build/ocaml/config/m.h
+endif
 	cp config/Makefile.$(BUILD_OS).$(BUILD_ARCH) build/ocaml/config/Makefile
 
 # Needed for OCaml >= 4.03.0, triggered by OCAML_EXTRA_DEPS via Makeconf
@@ -37,19 +42,37 @@ build/ocaml/byterun/caml/version.h: build/ocaml/config/Makefile
 OCAML_CFLAGS=-O2 -fno-strict-aliasing -fwrapv -Wall -USYS_linux -DHAS_UNISTD $(FREESTANDING_CFLAGS)
 OCAML_CFLAGS+=-I$(TOP)/build/openlibm/include -I$(TOP)/build/openlibm/src
 build/ocaml/asmrun/libasmrun.a: build/ocaml/config/Makefile build/openlibm/Makefile $(OCAML_EXTRA_DEPS)
+ifeq ($(OCAML_NEW_MAKEFILES),yes)
+	$(MAKE) -C build/ocaml/asmrun \
+	    UNIX_OR_WIN32=unix \
+	    CFLAGS="$(OCAML_CFLAGS)" \
+	    libasmrun.a
+else
 	$(MAKE) -C build/ocaml/asmrun \
 	    UNIX_OR_WIN32=unix \
 	    NATIVECCCOMPOPTS="$(OCAML_CFLAGS)" \
 	    NATIVECCPROFOPTS="$(OCAML_CFLAGS)" \
 	    libasmrun.a
+endif
 
 build/ocaml/otherlibs/libotherlibs.a: build/ocaml/config/Makefile
+ifeq ($(OCAML_NEW_MAKEFILES),yes)
+	$(MAKE) -C build/ocaml/otherlibs/bigarray \
+	    OUTPUTOBJ=-o \
+	    CFLAGS="$(FREESTANDING_CFLAGS) -DIN_OCAML_BIGARRAY -I../../byterun" \
+	    bigarray_stubs.o mmap_ba.o mmap.o
+	$(AR) rcs $@ \
+	    build/ocaml/otherlibs/bigarray/bigarray_stubs.o \
+	    build/ocaml/otherlibs/bigarray/mmap_ba.o \
+	    build/ocaml/otherlibs/bigarray/mmap.o
+else
 	$(MAKE) -C build/ocaml/otherlibs/bigarray \
 	    CFLAGS="$(FREESTANDING_CFLAGS) -I../../byterun" \
 	    bigarray_stubs.o mmap_unix.o
 	$(AR) rcs $@ \
 	    build/ocaml/otherlibs/bigarray/bigarray_stubs.o \
 	    build/ocaml/otherlibs/bigarray/mmap_unix.o
+endif
 
 build/nolibc/Makefile:
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build/ocaml/Makefile:
 	cp -r `ocamlfind query ocaml-src` build/ocaml
 
 build/ocaml/config/Makefile: build/ocaml/Makefile
-ifeq ($(OCAML_NEW_MAKEFILES),yes)
+ifeq ($(OCAML_GTE_4_06_0),yes)
 	cp config/s.h build/ocaml/byterun/caml/s.h
 	cp config/m.$(BUILD_ARCH).h build/ocaml/byterun/caml/m.h
 else
@@ -42,7 +42,7 @@ build/ocaml/byterun/caml/version.h: build/ocaml/config/Makefile
 OCAML_CFLAGS=-O2 -fno-strict-aliasing -fwrapv -Wall -USYS_linux -DHAS_UNISTD $(FREESTANDING_CFLAGS)
 OCAML_CFLAGS+=-I$(TOP)/build/openlibm/include -I$(TOP)/build/openlibm/src
 build/ocaml/asmrun/libasmrun.a: build/ocaml/config/Makefile build/openlibm/Makefile $(OCAML_EXTRA_DEPS)
-ifeq ($(OCAML_NEW_MAKEFILES),yes)
+ifeq ($(OCAML_GTE_4_06_0),yes)
 	$(MAKE) -C build/ocaml/asmrun \
 	    UNIX_OR_WIN32=unix \
 	    CFLAGS="$(OCAML_CFLAGS)" \
@@ -56,7 +56,7 @@ else
 endif
 
 build/ocaml/otherlibs/libotherlibs.a: build/ocaml/config/Makefile
-ifeq ($(OCAML_NEW_MAKEFILES),yes)
+ifeq ($(OCAML_GTE_4_06_0),yes)
 	$(MAKE) -C build/ocaml/otherlibs/bigarray \
 	    OUTPUTOBJ=-o \
 	    CFLAGS="$(FREESTANDING_CFLAGS) -DIN_OCAML_BIGARRAY -I../../byterun" \

--- a/configure.sh
+++ b/configure.sh
@@ -40,7 +40,7 @@ if [ "${BUILD_ARCH}" = "aarch64" ]; then
 fi
 
 cp -r config.in config
-OCAML_NEW_MAKEFILES=no
+OCAML_GTE_4_06_0=no
 case $(ocamlopt -version) in
     4.02.3)
         echo '#define OCAML_OS_TYPE "Unix"' >> config/s.h
@@ -67,7 +67,7 @@ case $(ocamlopt -version) in
         echo 'afl.o: CFLAGS+=-D__ANDROID__' >> config/Makefile.${BUILD_OS}.${BUILD_ARCH}
         ;;
     4.06.[0-9]|4.06.[0-9]+*)
-        OCAML_NEW_MAKEFILES=yes
+        OCAML_GTE_4_06_0=yes
         OCAML_EXTRA_DEPS=build/ocaml/byterun/caml/version.h
         echo '#define OCAML_OS_TYPE "freestanding"' >> config/s.h
         echo '#define INT64_LITERAL(s) s ## LL' >> config/m.${BUILD_ARCH}.h
@@ -87,5 +87,5 @@ NOLIBC_SYSDEP_OBJS=sysdeps_solo5.o
 PKG_CONFIG_DEPS=${PKG_CONFIG_DEPS}
 PKG_CONFIG_EXTRA_LIBS=${PKG_CONFIG_EXTRA_LIBS}
 OCAML_EXTRA_DEPS=${OCAML_EXTRA_DEPS}
-OCAML_NEW_MAKEFILES=${OCAML_NEW_MAKEFILES}
+OCAML_GTE_4_06_0=${OCAML_GTE_4_06_0}
 EOM

--- a/configure.sh
+++ b/configure.sh
@@ -40,6 +40,7 @@ if [ "${BUILD_ARCH}" = "aarch64" ]; then
 fi
 
 cp -r config.in config
+OCAML_NEW_MAKEFILES=no
 case $(ocamlopt -version) in
     4.02.3)
         echo '#define OCAML_OS_TYPE "Unix"' >> config/s.h
@@ -65,6 +66,13 @@ case $(ocamlopt -version) in
         # add many more stubs to ocaml-freestanding.
         echo 'afl.o: CFLAGS+=-D__ANDROID__' >> config/Makefile.${BUILD_OS}.${BUILD_ARCH}
         ;;
+    4.06.[0-9]|4.06.[0-9]+*)
+        OCAML_NEW_MAKEFILES=yes
+        OCAML_EXTRA_DEPS=build/ocaml/byterun/caml/version.h
+        echo '#define OCAML_OS_TYPE "freestanding"' >> config/s.h
+        echo '#define INT64_LITERAL(s) s ## LL' >> config/m.${BUILD_ARCH}.h
+        echo 'SYSTEM=freestanding' >> config/Makefile.${BUILD_OS}.${BUILD_ARCH}
+        ;;
     *)
         echo "ERROR: Unsupported OCaml version: $(ocamlopt -version)." 1>&2
         exit 1
@@ -79,4 +87,5 @@ NOLIBC_SYSDEP_OBJS=sysdeps_solo5.o
 PKG_CONFIG_DEPS=${PKG_CONFIG_DEPS}
 PKG_CONFIG_EXTRA_LIBS=${PKG_CONFIG_EXTRA_LIBS}
 OCAML_EXTRA_DEPS=${OCAML_EXTRA_DEPS}
+OCAML_NEW_MAKEFILES=${OCAML_NEW_MAKEFILES}
 EOM

--- a/install.sh
+++ b/install.sh
@@ -21,18 +21,26 @@ cp build/openlibm/libopenlibm.a ${DESTLIB}
 OCAML_INCLUDES="alloc.h callback.h config.h custom.h fail.h hash.h intext.h \
   memory.h misc.h mlvalues.h printexc.h signals.h compatibility.h"
 mkdir -p ${DESTINC}/caml
-# Ocaml public headers need to be cleaned up before installation:
-# 'cleanup-header' uses relative paths to read headers in "../config", hence the
-# nested shell and use of 'cd' here.
-(
-    cd build/ocaml/byterun
+# Prior to OCaml 4.06.0, public headers need to be cleaned up before
+# installation: 'cleanup-header' uses relative paths to read headers in
+# "../config", hence the nested shell and use of 'cd' here.
+if [ -f build/ocaml/tools/cleanup-header ]; then
+    (
+        cd build/ocaml/byterun
+        for f in ${OCAML_INCLUDES}; do
+            sed -f ../tools/cleanup-header caml/${f} >${DESTINC}/caml/${f}
+        done
+    )
+    cp build/ocaml/otherlibs/bigarray/bigarray.h ${DESTINC}/caml/bigarray.h
+else
+# Assume OCaml >= 4.06.0 here.
+    OCAML_INCLUDES="${OCAML_INCLUDES} bigarray.h m.h s.h"
     for f in ${OCAML_INCLUDES}; do
-	sed -f ../tools/cleanup-header caml/${f} >${DESTINC}/caml/${f}
+        cp build/ocaml/byterun/caml/${f} ${DESTINC}/caml/${f}
     done
-)
+fi
 cp build/ocaml/asmrun/libasmrun.a ${DESTLIB}/libasmrun.a
 # OCaml "otherlibs"
-cp build/ocaml/otherlibs/bigarray/bigarray.h ${DESTINC}/caml/bigarray.h
 cp build/ocaml/otherlibs/libotherlibs.a ${DESTLIB}/libotherlibs.a
 
 # pkg-config

--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ conflicts: [
   "sexplib" {= "v0.9.0"}
 ]
 available: [
-  ocaml-version >= "4.02.3" & ocaml-version < "4.06.0" &
+  ocaml-version >= "4.02.3" & ocaml-version < "4.07.0" &
   ((os = "linux" & (arch = "x86_64" | arch = "aarch64") |
    (os = "freebsd" & arch = "amd64")))
 ]


### PR DESCRIPTION
Due to the refactoring of the compiler build system in 4.06.0 this is not the usual trivial change, and now needs separate paths for >= 4.06.0. I'm not entirely happy with the hacks involved but "it works for me".

Tested on Linux with ukvm and the mirage-skeleton `device-usage/network` example; I'd appreciate more testing and review from others before merging this (/cc @hannesm).
