### PR TITLE
update ocaml-freestanding with new solo5 API regarding solo5_exit taking an int

### DIFF
--- a/nolibc/sysdeps_solo5.c
+++ b/nolibc/sysdeps_solo5.c
@@ -36,13 +36,13 @@ ssize_t write(int fd, const void *buf, size_t count)
 
 void exit(int status)
 {
-    solo5_exit();
+    solo5_exit(status);
 }
 
 void abort(void)
 {
     solo5_console_write("Aborted\n", 8);
-    solo5_exit();
+    solo5_exit(SOLO5_EXIT_FAILURE);
 }
 
 /*


### PR DESCRIPTION
once https://github.com/Solo5/solo5/pull/230 is merged, this updates ocaml-freestanding to the new API