### PR TITLE
opam, Travis CI: Switch to Solo5 master for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script: bash -ex .travis-opam.sh
 env:
     global:
         - TESTS=false
+        - EXTRA_REMOTES="git://github.com/Solo5/opam-solo5"
     matrix:
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-ukvm"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-virtio"
@@ -13,7 +14,3 @@ env:
         - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-kernel-virtio"
         - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-ukvm"
         - OCAML_VERSION=4.04 EXTRA_DEPS="solo5-kernel-virtio"
-        - OCAML_VERSION=4.03 EXTRA_DEPS="solo5-kernel-ukvm"
-        - OCAML_VERSION=4.03 EXTRA_DEPS="solo5-kernel-virtio"
-        - OCAML_VERSION=4.02 EXTRA_DEPS="solo5-kernel-ukvm"
-        - OCAML_VERSION=4.02 EXTRA_DEPS="solo5-kernel-virtio"

--- a/opam
+++ b/opam
@@ -13,13 +13,13 @@ depends: [
   "conf-pkg-config"
   "ocamlfind"
   "ocaml-src"
-  ("solo5-kernel-ukvm" | "solo5-kernel-virtio" | "solo5-kernel-muen")
+  ("solo5-kernel-ukvm" {>= "0.3.0"} | "solo5-kernel-virtio" {>= "0.3.0"} | "solo5-kernel-muen" {>= "0.3.0"})
 ]
 conflicts: [
   "sexplib" {= "v0.9.0"}
 ]
 available: [
-  ocaml-version >= "4.02.3" & ocaml-version < "4.07.0" &
+  ocaml-version >= "4.04.2" & ocaml-version < "4.07.0" &
   ((os = "linux" & (arch = "x86_64" | arch = "aarch64") |
    (os = "freebsd" & arch = "amd64")))
 ]


### PR DESCRIPTION
Now that Solo5/opam-solo5 is back online for development on master,
switch ocaml-freestanding to it by adding EXTRA_REMOTES to Travis CI and
updating OPAM metadata to depend on Solo5 >= 0.3.0.

As part of this, based on the earlier consensus on mirage-dev regarding
supported compiler versions and to speed up Travis CI cycles, remove
compilers older than 4.04.2 from the build matrix and update
ocaml-version in opam.