### PR TITLE
cleanup README.md, configure.sh, and opam to meet on OCaml versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ocaml-freestanding` during the link step.
 
 ## Supported compiler versions
 
-Tested against OCaml 4.02.3, 4.03.0 and 4.04.0. Other versions will require
+Tested against OCaml 4.04.2, 4.05.0 and 4.06.0. Other versions will require
 changing `configure.sh`.
 
 ## Porting to a different (uni)kernel base layer

--- a/configure.sh
+++ b/configure.sh
@@ -42,17 +42,6 @@ fi
 cp -r config.in config
 OCAML_GTE_4_06_0=no
 case $(ocamlopt -version) in
-    4.02.3)
-        echo '#define OCAML_OS_TYPE "Unix"' >> config/s.h
-        ;;
-    4.03.0)
-        OCAML_EXTRA_DEPS=build/ocaml/byterun/caml/version.h
-        echo '#define OCAML_OS_TYPE "Unix"' >> config/s.h
-        ;;
-    4.04.0|4.04.0+*)
-        OCAML_EXTRA_DEPS=build/ocaml/byterun/caml/version.h
-        echo '#define OCAML_OS_TYPE "freestanding"' >> config/s.h
-        ;;
     4.04.[1-9]|4.04.[1-9]+*)
         OCAML_EXTRA_DEPS=build/ocaml/byterun/caml/version.h
         echo '#define OCAML_OS_TYPE "freestanding"' >> config/s.h


### PR DESCRIPTION
since we dropped <4.04.2 in opam, we should also drop these versions from README and configure