### PR TITLE
Fix opam arch constraint

### DIFF
--- a/opam
+++ b/opam
@@ -20,6 +20,6 @@ conflicts: [
 ]
 available: [
   ocaml-version >= "4.04.2" & ocaml-version < "4.07.0" &
-  ((os = "linux" & (arch = "x86_64" | arch = "aarch64") |
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64") |
    (os = "freebsd" & arch = "amd64")))
 ]


### PR DESCRIPTION
```arm64``` is the correct arch name not ```aarch64```