### PR TITLE
OCaml 4.07 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     global:
         - TESTS=false
         - PACKAGE="ocaml-freestanding"
+        - OPAM_VERSION=1.2.2
     matrix:
         - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-kernel-ukvm"
         - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-kernel-virtio"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ script: bash -ex .travis-opam.sh
 env:
     global:
         - TESTS=false
+        - PACKAGE="ocaml-freestanding"
     matrix:
+        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-kernel-ukvm"
+        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-kernel-virtio"
+        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-kernel-muen"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-ukvm"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-virtio"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-kernel-muen"

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
 .PHONY: all clean install
+
+include Makeconf
+
+ifeq ($(OCAML_GTE_4_07_0),yes)
+FREESTANDING_LIBS=build/openlibm/libopenlibm.a \
+		  build/ocaml/asmrun/libasmrun.a \
+		  build/nolibc/libnolibc.a
+else
 FREESTANDING_LIBS=build/openlibm/libopenlibm.a \
 		  build/ocaml/asmrun/libasmrun.a \
 		  build/ocaml/otherlibs/libotherlibs.a \
 		  build/nolibc/libnolibc.a
+endif
 
 all:	$(FREESTANDING_LIBS) ocaml-freestanding.pc
-
-include Makeconf
 
 Makeconf:
 	./configure.sh

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ endif
 build/nolibc/Makefile:
 	mkdir -p build
 	cp -r nolibc build
+ifeq ($(OCAML_GTE_4_07_0),yes)
+	echo '/* automatically added by configure.sh */' >> build/nolibc/stubs.c
+	echo 'STUB_ABORT(caml_ba_map_file);' >> build/nolibc/stubs.c
+endif
 
 NOLIBC_CFLAGS=$(FREESTANDING_CFLAGS) -isystem $(TOP)/build/openlibm/src -isystem $(TOP)/build/openlibm/include
 build/nolibc/libnolibc.a: build/nolibc/Makefile build/openlibm/Makefile

--- a/install.sh
+++ b/install.sh
@@ -40,8 +40,12 @@ else
     done
 fi
 cp build/ocaml/asmrun/libasmrun.a ${DESTLIB}/libasmrun.a
-# OCaml "otherlibs"
-cp build/ocaml/otherlibs/libotherlibs.a ${DESTLIB}/libotherlibs.a
+
+# Prior to OCaml 4.07.0, "otherlibs" contained the bigarray implementation.
+# OCaml >= 4.07.0 includes bigarray as part of stdlib/libasmrun.a
+if [ -f build/ocaml/otherlibs/libotherlibs.a ]; then
+    cp build/ocaml/otherlibs/libotherlibs.a ${DESTLIB}/libotherlibs.a
+fi
 
 # pkg-config
 mkdir -p ${prefix}/lib/pkgconfig

--- a/nolibc/include/sys/ioctl.h
+++ b/nolibc/include/sys/ioctl.h
@@ -1,0 +1,4 @@
+#ifndef _SYS_IOCTL_H
+#define _SYS_IOCTL_H
+
+#endif

--- a/ocaml-freestanding.pc.in
+++ b/ocaml-freestanding.pc.in
@@ -5,8 +5,8 @@ libdir=${exec_prefix}/lib/ocaml-freestanding
 
 Name: ocaml-freestanding
 Version: 1.0.0
-URL: https://github.com/mirage/mirage-platform/
+URL: https://github.com/mirage/ocaml-freestanding/
 Description: Freestanding OCaml runtime
 Cflags: -I${includedir}
-Libs: ${libdir}/libasmrun.a ${libdir}/libotherlibs.a ${libdir}/libnolibc.a ${libdir}/libopenlibm.a @@PKG_CONFIG_EXTRA_LIBS@@
+Libs: -L${libdir} -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@
 Requires: @@PKG_CONFIG_DEPS@@

--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ conflicts: [
   "sexplib" {= "v0.9.0"}
 ]
 available: [
-  ocaml-version >= "4.04.2" & ocaml-version < "4.07.0" &
+  ocaml-version >= "4.04.2" & ocaml-version < "4.08.0" &
   ((os = "linux" & (arch = "x86_64" | arch = "aarch64") |
    (os = "freebsd" & arch = "amd64") | (os = "openbsd" & arch = "amd64" )))
 ]


### PR DESCRIPTION
Relevant changes in 4.07
- unix.c now #include <sys/ioctl.h> (since 852b595ff3), but an empty one is fine
  (only use is in caml_nun_rows_fd in an #ifdef TIOCGWINSZ), see
  https://github.com/ocaml/ocaml/pull/1431/
  -> provide an empty ioctl via nolibc
- bigarray is now part of the stdlib
  https://github.com/ocaml/ocaml/pull/1685
  -> libotherlibs.a is no longer needed (neither built nor linked)

this compiles, but has not been extensively tested due to ppx issues in 4.07 (and thus unable to build the mirage tool, but working on some hacks for that)