### PR TITLE
install an empty META file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,10 @@ if [ -f build/ocaml/otherlibs/libotherlibs.a ]; then
     cp build/ocaml/otherlibs/libotherlibs.a ${DESTLIB}/libotherlibs.a
 fi
 
+# META: ocamlfind and other build utilities test for existance ${DESTLIB}/META
+# when figuring out whether a library is installed
+touch ${DESTLIB}/META
+
 # pkg-config
 mkdir -p ${prefix}/lib/pkgconfig
 cp ocaml-freestanding.pc ${prefix}/lib/pkgconfig/ocaml-freestanding.pc


### PR DESCRIPTION
when not including the META file, other build systems won't recognize ocaml-freestanding to be installed, which makes it hard to depend on ocaml-freestanding being there (e.g. as depopt). would be worth releasing a 0.4.1 with this change since e.g. bigstringaf should be fixed with the correct dependencies.