### PR TITLE
use solo5_abort in abort

### DIFF
--- a/nolibc/sysdeps_solo5.c
+++ b/nolibc/sysdeps_solo5.c
@@ -45,7 +45,7 @@ void exit(int status)
 void abort(void)
 {
     solo5_console_write("Aborted\n", 8);
-    solo5_exit(SOLO5_EXIT_FAILURE);
+    solo5_abort();
 }
 
 /*


### PR DESCRIPTION
`solo5_abort` has been in solo5 since 0.3.0. OCaml-freestanding depends on 0.4.0 (the big rename) anyways ;)

`solo5_abort` will potentially dump a core file for later debugging. Before this PR, it was never called from the OCaml side.