### PR TITLE
Expose flags though files and enable the use of -runtime-variant

### DIFF
--- a/flags/cflags.tmp.in
+++ b/flags/cflags.tmp.in
@@ -1,0 +1,1 @@
+-I%{prefix}%/include/ocaml-freestanding

--- a/flags/libs.tmp.in
+++ b/flags/libs.tmp.in
@@ -1,0 +1,1 @@
+-L%{ocaml-freestanding:lib}% -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ else
     done
 fi
 cp build/ocaml/asmrun/libasmrun.a ${DESTLIB}/libasmrun.a
+ln -s ${DESTLIB}/libasmrun.a ${prefix}/lib/ocaml/libasmrunfreestanding.a
 
 # Prior to OCaml 4.07.0, "otherlibs" contained the bigarray implementation.
 # OCaml >= 4.07.0 includes bigarray as part of stdlib/libasmrun.a

--- a/install.sh
+++ b/install.sh
@@ -54,3 +54,5 @@ touch ${DESTLIB}/META
 # pkg-config
 mkdir -p ${prefix}/lib/pkgconfig
 cp ocaml-freestanding.pc ${prefix}/lib/pkgconfig/ocaml-freestanding.pc
+cp flags/cflags ${DESTLIB}
+cp flags/libs ${DESTLIB}

--- a/opam
+++ b/opam
@@ -16,6 +16,10 @@ depends: [
   ("solo5-bindings-hvt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")
   "ocaml" {>= "4.04.2" & < "4.08.0"}
 ]
+substs: [
+  "flags/cflags.tmp"
+  "flags/libs.tmp"
+]
 conflicts: [
   "sexplib" {= "v0.9.0"}
   "solo5-kernel-ukvm"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,3 +9,4 @@ odir=$prefix/lib
 rm -f $odir/pkgconfig/ocaml-freestanding.pc
 rm -rf $odir/ocaml-freestanding
 rm -rf $prefix/include/ocaml-freestanding
+rm -f $odir/ocaml/libasmrunfreestanding.a


### PR DESCRIPTION
For [mirage/mirage#969](https://github.com/mirage/mirage/issues/969)

Instead of pkg-config, one can use the following files to get compilation flags:
* ocaml-freestanding/libs
* ocaml-freestanding/cflags

For example with dune this allows to write `%{lib:ocaml-freestanding:cflags}` to get the flags instead of having a script invoking `pkg-config ocaml-freestanding --cflags`.

Moreover `libasmrun.a` is symlinked in the ocaml directory in order to be able to use ocamlopt's `-runtime-variant` option.