### PR TITLE
allow non-opam installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ Makeconf
 build/
 config/
 ocaml-freestanding.pc
+flags/cflags
+flags/cflags.tmp
+flags/libs
+flags/libs.tmp
+flags/libs.tmp2

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ flags/cflags
 flags/cflags.tmp
 flags/libs
 flags/libs.tmp
-flags/libs.tmp2

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ ocaml-freestanding.pc: ocaml-freestanding.pc.in Makeconf
 	    -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
 	    ocaml-freestanding.pc.in > $@
 
+flags/libs.tmp:
+	opam config subst $@
+
 flags/libs: flags/libs.tmp Makeconf
 	sed -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
 	    flags/libs.tmp > flags/libs.tmp2
@@ -108,6 +111,9 @@ flags/libs: flags/libs.tmp Makeconf
 		env PKG_CONFIG_PATH=$(shell opam config var prefix)/lib/pkgconfig pkg-config $$PKG --libs >> flags/libs.tmp2;\
 	done
 	echo "("`cat flags/libs.tmp2`")" > flags/libs
+
+flags/cflags.tmp:
+	opam config subst $@
 
 flags/cflags: flags/cflags.tmp Makeconf
 	for PKG in $(PKG_CONFIG_DEPS); do \
@@ -126,3 +132,5 @@ uninstall:
 
 clean:
 	rm -rf build config Makeconf ocaml-freestanding.pc
+	rm -rf flags/libs flags/libs.tmp flags/libs.tmp2
+	rm -rf flags/cflags flags/cflags.tmp

--- a/Makefile
+++ b/Makefile
@@ -105,18 +105,21 @@ flags/libs.tmp: flags/libs.tmp.in
 
 flags/libs: flags/libs.tmp Makeconf
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
-	    pkg-config $(PKG_CONFIG_DEPS) --libs >> flags/libs.tmp
-	echo "("`cat flags/libs.tmp`")" \
-	    | sed -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
-	    > flags/libs
+	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
+	sed -e '1i (' \
+            -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
+	    -e '$$a )' \
+	    $< > $@
 
 flags/cflags.tmp: flags/cflags.tmp.in
 	opam config subst $@
 
 flags/cflags: flags/cflags.tmp Makeconf
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
-	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> flags/cflags.tmp
-	echo "("`cat flags/cflags.tmp`")" > flags/cflags
+	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
+	sed -e '1i (' \
+	    -e '$$a )' \
+	    $< > $@
 
 install: all
 	./install.sh

--- a/Makefile
+++ b/Makefile
@@ -100,29 +100,23 @@ ocaml-freestanding.pc: ocaml-freestanding.pc.in Makeconf
 	    -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
 	    ocaml-freestanding.pc.in > $@
 
-flags/libs.tmp:
+flags/libs.tmp: flags/libs.tmp.in
 	opam config subst $@
 
 flags/libs: flags/libs.tmp Makeconf
-	sed -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
-	    flags/libs.tmp > flags/libs.tmp2
-	for PKG in $(PKG_CONFIG_DEPS); do \
-		echo " " >> flags/libs.tmp2;\
-		env PKG_CONFIG_PATH=$(shell opam config var prefix)/lib/pkgconfig pkg-config $$PKG --libs >> flags/libs.tmp2;\
-	done
-	echo "("`cat flags/libs.tmp2`")" > flags/libs
+	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
+	    pkg-config $(PKG_CONFIG_DEPS) --libs >> flags/libs.tmp
+	echo "("`cat flags/libs.tmp`")" \
+	    | sed -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
+	    > flags/libs
 
-flags/cflags.tmp:
+flags/cflags.tmp: flags/cflags.tmp.in
 	opam config subst $@
 
 flags/cflags: flags/cflags.tmp Makeconf
-	for PKG in $(PKG_CONFIG_DEPS); do \
-		echo " " >> flags/cflags.tmp;\
-		env PKG_CONFIG_PATH=$(shell opam config var prefix)/lib/pkgconfig pkg-config $$PKG --cflags >> flags/cflags.tmp;\
-	done
+	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
+	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> flags/cflags.tmp
 	echo "("`cat flags/cflags.tmp`")" > flags/cflags
-
-
 
 install: all
 	./install.sh
@@ -132,5 +126,5 @@ uninstall:
 
 clean:
 	rm -rf build config Makeconf ocaml-freestanding.pc
-	rm -rf flags/libs flags/libs.tmp flags/libs.tmp2
+	rm -rf flags/libs flags/libs.tmp
 	rm -rf flags/cflags flags/cflags.tmp


### PR DESCRIPTION
Makefile: provide rules for flags/libs.tmp and flags/cflags.tmp, clean: rm them
.gitignore: ignore remporary generated flags files

this improves local non-opam builds after c5bf86c /cc @TheLortex