### PR TITLE
do not claim to support POSIX_SIGNALS, provide alternative symbols

### DIFF
--- a/config.in/s.h
+++ b/config.in/s.h
@@ -1,5 +1,5 @@
 #define OCAML_STDLIB_DIR "/usr/local/lib/ocaml"
-#define POSIX_SIGNALS
+//#define POSIX_SIGNALS
 //#define HAS_GETRUSAGE
 #define HAS_TIMES
 //#define HAS_SOCKETS

--- a/nolibc/include/signal.h
+++ b/nolibc/include/signal.h
@@ -1,23 +1,12 @@
 #ifndef _SIGNAL_H
 #define _SIGNAL_H
 
-typedef int sigjmp_buf;
-typedef int sigset_t;
-struct sigaction {
-    void (*sa_handler)(int);
-    sigset_t sa_mask;
-    int sa_flags;
-};
+typedef int jmp_buf;
+int setjmp(jmp_buf);
+void (*signal(int sig, void (*func)(int)))(int);
 #define SIG_DFL NULL
 #define SIG_IGN NULL
-int sigaction(int, const struct sigaction *, struct sigaction *);
-int sigsetjmp(sigjmp_buf, int);
-int sigaddset(sigset_t *set, int);
-int sigdelset(sigset_t *set, int);
-int sigemptyset(sigset_t *set);
-#define SIG_BLOCK 0
-#define SIG_SETMASK 0
-int sigprocmask(int, const sigset_t *, sigset_t *);
+#define SIG_ERR NULL
 /*
  * The following definitions are not required by the OCaml runtime, but are
  * needed to build the freestanding version of GMP used by Mirage.

--- a/nolibc/stubs.c
+++ b/nolibc/stubs.c
@@ -85,12 +85,8 @@ STUB_ABORT(fcntl);
 STUB_WARN_ONCE(int, open, -1);
 
 /* signal.h */
-STUB_IGNORE(int, sigaction, -1);
-STUB_IGNORE(int, sigsetjmp, 0);
-STUB_IGNORE(int, sigaddset, -1);
-STUB_IGNORE(int, sigdelset, -1);
-STUB_IGNORE(int, sigemptyset, -1);
-STUB_IGNORE(int, sigprocmask, -1);
+STUB_IGNORE(int, setjmp, 0);
+STUB_ABORT(signal);
 /*
  * The following stubs are not required by the OCaml runtime, but are
  * needed to build the freestanding version of GMP used by Mirage.


### PR DESCRIPTION
s.h: do not define POSIX_SIGNALS
signal.h: define jmp_buf, signal, setjmp
  remove sigaction/sigsetjmp/sigaddset/sigdelset/sigemptyset/sigprocmask
stubs.c: see above

The motivation for this change is that my last porting to OCaml 4.08.0 attempt required more symbols due to changes to the signal handling. with this change in, it should be easier. I tested this change with OCaml 4.07.1 and actual unikernels (hello/prng/network from mirage-skeleton), and compiled gmp-freestanding, which works flawlessly.

There is a downside, though: the binary size of libasmrun.a increased by 176 bytes. The upside is that nolibc.a reduced by 1168 bytes, so ultimately it saves around 1000 bytes _per unikernel_.

Please let me know what you think about this, to me it is an improvement (fewer symbols, the OCaml runtime code in question is never executed anyways).