### PR TITLE
dlmalloc: expose struct mallinfo mallinfo () -- malloc statistics

### DIFF
--- a/nolibc/include/stdlib.h
+++ b/nolibc/include/stdlib.h
@@ -9,6 +9,21 @@ void *malloc(size_t);
 void free(void *);
 void *calloc(size_t, size_t);
 void *realloc(void *, size_t);
+
+struct mallinfo {
+  size_t arena;    /* non-mmapped space allocated from system */
+  size_t ordblks;  /* number of free chunks */
+  size_t smblks;   /* always 0 */
+  size_t hblks;    /* always 0 */
+  size_t hblkhd;   /* space in mmapped regions */
+  size_t usmblks;  /* maximum total allocated space */
+  size_t fsmblks;  /* always 0 */
+  size_t uordblks; /* total allocated space */
+  size_t fordblks; /* total free space */
+  size_t keepcost; /* releasable (via malloc_trim) space */
+};
+struct mallinfo mallinfo(void);
+
 char *getenv(const char *);
 char *secure_getenv(const char *);
 int system(const char *);

--- a/nolibc/sysdeps_solo5.c
+++ b/nolibc/sysdeps_solo5.c
@@ -133,7 +133,7 @@ void *sbrk(intptr_t increment)
 #else
 #undef assert
 #define assert(x)
-#define NO_MALLINFO 1
+#define STRUCT_MALLINFO_DECLARED 1
 #endif
 
 #undef WIN32


### PR DESCRIPTION
my motivation is gathering metrics from unikernels. The OCaml runtime provides access to the garbage collector statistics, but not every byte allocated in OCaml is going through OCaml's gc (bigarray/cstruct/io-page do not). Now, dlmalloc has built-in statistics that can be enabled via a define (there are actually two, MALLINFO and MALLOC_STATS - where the latter prints statistics on stdout -- I propose only to enable MALLINFO).

What is the impact? There is no work done during each malloc or free, but instead the function `mallinfo()` walks over the heap and gathers a set of statistics. This means, mallinfo() is (rather) expensive to call, but there's no time or space downside for users who are not interested in mallinfo.

I added the mallinfo struct and mallinfo function to stdlib.h, where the other malloc-exported functions are. If there is a better place for these, I'm fine with this as well (maybe malloc.h?). The standard type (in dlmalloc.i) for mallinfo members is `size_t` (but can be overriden via a define - we don't do that).

EDIT: I have deployed this change, together with changes in mirage-solo5 that bind `mallinfo ()` and expose it as metrics (called every 10s), reporting to influx/grafana - see https://github.com/hannesm/monitoring-experiments if you're interested.