### PR TITLE
fixes for BSD sed compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,22 +103,24 @@ ocaml-freestanding.pc: ocaml-freestanding.pc.in Makeconf
 flags/libs.tmp: flags/libs.tmp.in
 	opam config subst $@
 
-flags/libs: flags/libs.tmp Makeconf
+PKG_CONFIG_LIBS != \
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
-	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
-	sed -e '1i (' \
-            -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
-	    -e '$$a )' \
+	    pkg-config $(PKG_CONFIG_DEPS) --libs
+
+flags/libs: flags/libs.tmp Makeconf
+	sed -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
+	    -e 's!@@PKG_CONFIG_LIBS@@!$(PKG_CONFIG_LIBS)!' \
 	    $< > $@
 
 flags/cflags.tmp: flags/cflags.tmp.in
 	opam config subst $@
 
-flags/cflags: flags/cflags.tmp Makeconf
+PKG_CONFIG_CFLAGS != \
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
-	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
-	sed -e '1i (' \
-	    -e '$$a )' \
+	    pkg-config $(PKG_CONFIG_DEPS) --cflags
+
+flags/cflags: flags/cflags.tmp Makeconf
+	sed -e 's!@@PKG_CONFIG_CFLAGS@@!$(PKG_CONFIG_CFLAGS)!' \
 	    $< > $@
 
 install: all

--- a/flags/cflags.tmp.in
+++ b/flags/cflags.tmp.in
@@ -1,1 +1,1 @@
--I%{prefix}%/include/ocaml-freestanding
+(-I%{prefix}%/include/ocaml-freestanding @@PKG_CONFIG_CFLAGS@@)

--- a/flags/libs.tmp.in
+++ b/flags/libs.tmp.in
@@ -1,1 +1,1 @@
--L%{ocaml-freestanding:lib}% -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@
+(-L%{ocaml-freestanding:lib}% -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@ @@PKG_CONFIG_LIBS@@)


### PR DESCRIPTION
sorry, I wasn't carefully trying #52 on BSD.

It turns out that the expression `sed -e '1i (' ` (and `a`) does not work with BSD sed:
```
sed: 1: "1i (
": command i expects \ followed by text
```

I found some explanation [here](https://riptutorial.com/sed/topic/9436/bsd-macos-sed-vs--gnu-sed-vs--the-posix-sed-specification), using the proposed `sed -e '1 i\'$'\n''('`works in a shell, but via the Makefile leads to a leading `$` on a Linux (debian) system -- it works fine on FreeBSD :/

Instead, we can use sed replacements (and shell invocation) as done in this PR, and provide the parens in the `.in` files.

(Another solution I came up with is another conditional in Makefile:
```make
ifeq ($(BUILD_OS),Linux)
SED_POST=
else
SED_POST=\'$$'\n''
endif
```
and then `sed -e '1 i$(SED_POST)('` in the rules, but IMHO that one is less readable than the provided diff).