### PR TITLE
Makefile: Use awk instead of sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,10 @@ flags/libs.tmp: flags/libs.tmp.in
 flags/libs: flags/libs.tmp Makeconf
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
 	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
-	sed -e '1i (' \
-            -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
-	    -e '$$a )' \
-	    $< > $@
+	awk -v RS= -- '{ \
+	    sub("@@PKG_CONFIG_EXTRA_LIBS@@", "$(PKG_CONFIG_EXTRA_LIBS)", $$0); \
+	    print "(", $$0, ")" \
+	    }' $< >$@
 
 flags/cflags.tmp: flags/cflags.tmp.in
 	opam config subst $@
@@ -117,9 +117,9 @@ flags/cflags.tmp: flags/cflags.tmp.in
 flags/cflags: flags/cflags.tmp Makeconf
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
 	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
-	sed -e '1i (' \
-	    -e '$$a )' \
-	    $< > $@
+	awk -v RS= -- '{ \
+	    print "(", $$0, ")" \
+	    }' $< >$@
 
 install: all
 	./install.sh


### PR DESCRIPTION
Use awk instead of sed for generating flags/..., this solution is
compatible with both GNU/Linux and BSD based systems.