### PR TITLE
Drop support for OCaml 4.05.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,25 @@
 language: c
-sudo: required
-dist: trusty
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+services:
+  - docker
+sudo: false
 env:
-    global:
-        - TESTS=false
-        - PACKAGE="ocaml-freestanding"
-        - POST_INSTALL_HOOK="./.travis-test-mirage.sh"
-    matrix:
-        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt" MIRAGE_TEST_MODE="hvt"
-        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-virtio" MIRAGE_TEST_MODE="virtio"
-        - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-muen" MIRAGE_TEST_MODE="muen"
-        - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-hvt" MIRAGE_TEST_MODE="hvt"
-        - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-virtio" MIRAGE_TEST_MODE="virtio"
-        - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-muen" MIRAGE_TEST_MODE="muen"
-        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-hvt" MIRAGE_TEST_MODE="hvt"
-        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-virtio" MIRAGE_TEST_MODE="virtio"
-        - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-muen" MIRAGE_TEST_MODE="muen"
-        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-hvt" MIRAGE_TEST_MODE="hvt"
-        - OCAML_VERSION=4.06 INSTALL_LOCAL=1 EXTRA_DEPS="solo5-bindings-virtio" MIRAGE_TEST_MODE="virtio"
-        - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-muen" MIRAGE_TEST_MODE="muen"
+ global:
+   - TESTS=false
+   - PACKAGE="ocaml-freestanding"
+   - POST_INSTALL_HOOK="./.travis-test-mirage.sh"
+   - DISTRO=alpine
+ matrix:
+   - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
+   - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-virtio" EXTRA_ENV="MIRAGE_TEST_MODE=virtio"
+   - OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-muen" EXTRA_ENV="MIRAGE_TEST_MODE=muen"
+   - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
+   - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-virtio" EXTRA_ENV="MIRAGE_TEST_MODE=virtio"
+   - OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-muen" EXTRA_ENV="MIRAGE_TEST_MODE=muen"
+   - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
+   - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-virtio" EXTRA_ENV="MIRAGE_TEST_MODE=virtio"
+   - OCAML_VERSION=4.07 EXTRA_DEPS="solo5-bindings-muen" EXTRA_ENV="MIRAGE_TEST_MODE=muen"
+   - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
+   - OCAML_VERSION=4.06 INSTALL_LOCAL=1 EXTRA_DEPS="solo5-bindings-virtio" EXTRA_ENV="MIRAGE_TEST_MODE=virtio"
+   - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-muen" EXTRA_ENV="MIRAGE_TEST_MODE=muen"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,3 @@ env:
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-hvt" MIRAGE_TEST_MODE="hvt"
         - OCAML_VERSION=4.06 INSTALL_LOCAL=1 EXTRA_DEPS="solo5-bindings-virtio" MIRAGE_TEST_MODE="virtio"
         - OCAML_VERSION=4.06 EXTRA_DEPS="solo5-bindings-muen" MIRAGE_TEST_MODE="muen"
-        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-bindings-hvt" MIRAGE_TEST_MODE="hvt"
-        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-bindings-virtio" MIRAGE_TEST_MODE="virtio"
-        - OCAML_VERSION=4.05 EXTRA_DEPS="solo5-bindings-muen" MIRAGE_TEST_MODE="muen"

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,8 @@ build/ocaml/Makefile:
 # Used to configure OCaml < 4.08.0
 ifneq ($(OCAML_GTE_4_08_0),yes)
 build/ocaml/config/Makefile: build/ocaml/Makefile
-ifeq ($(OCAML_GTE_4_06_0),yes)
 	cp config/s.h build/ocaml/byterun/caml/s.h
 	cp config/m.$(BUILD_ARCH).h build/ocaml/byterun/caml/m.h
-else
-	cp config/s.h build/ocaml/config/s.h
-	cp config/m.$(BUILD_ARCH).h build/ocaml/config/m.h
-endif
 	cp config/Makefile.$(BUILD_OS).$(BUILD_ARCH) build/ocaml/config/Makefile
 endif
 
@@ -78,23 +73,15 @@ build/ocaml/runtime/libasmrun.a: build/ocaml/Makefile.common build/ocaml/Makefil
 	    UNIX_OR_WIN32=unix \
 	    OC_CFLAGS="$(OCAML_CFLAGS)" \
 	    libasmrun.a
-else ifeq ($(OCAML_GTE_4_06_0),yes)
+else
 build/ocaml/asmrun/libasmrun.a: build/ocaml/config/Makefile build/openlibm/Makefile $(OCAML_EXTRA_DEPS)
 	$(MAKE) -C build/ocaml/asmrun \
 	    UNIX_OR_WIN32=unix \
 	    CFLAGS="$(OCAML_CFLAGS)" \
 	    libasmrun.a
-else
-build/ocaml/asmrun/libasmrun.a: build/ocaml/config/Makefile build/openlibm/Makefile $(OCAML_EXTRA_DEPS)
-	$(MAKE) -C build/ocaml/asmrun \
-	    UNIX_OR_WIN32=unix \
-	    NATIVECCCOMPOPTS="$(OCAML_CFLAGS)" \
-	    NATIVECCPROFOPTS="$(OCAML_CFLAGS)" \
-	    libasmrun.a
 endif
 
 build/ocaml/otherlibs/libotherlibs.a: build/ocaml/config/Makefile
-ifeq ($(OCAML_GTE_4_06_0),yes)
 	$(MAKE) -C build/ocaml/otherlibs/bigarray \
 	    OUTPUTOBJ=-o \
 	    CFLAGS="$(FREESTANDING_CFLAGS) -DIN_OCAML_BIGARRAY -I../../byterun" \
@@ -103,14 +90,6 @@ ifeq ($(OCAML_GTE_4_06_0),yes)
 	    build/ocaml/otherlibs/bigarray/bigarray_stubs.o \
 	    build/ocaml/otherlibs/bigarray/mmap_ba.o \
 	    build/ocaml/otherlibs/bigarray/mmap.o
-else
-	$(MAKE) -C build/ocaml/otherlibs/bigarray \
-	    CFLAGS="$(FREESTANDING_CFLAGS) -I../../byterun" \
-	    bigarray_stubs.o mmap_unix.o
-	$(AR) rcs $@ \
-	    build/ocaml/otherlibs/bigarray/bigarray_stubs.o \
-	    build/ocaml/otherlibs/bigarray/mmap_unix.o
-endif
 
 build/nolibc/Makefile:
 	mkdir -p build

--- a/configure.sh
+++ b/configure.sh
@@ -37,27 +37,16 @@ if [ ! -f config.in/Makefile.${BUILD_OS}.${BUILD_ARCH} ]; then
 fi
 
 cp -r config.in config
-OCAML_GTE_4_06_0=no
 OCAML_GTE_4_07_0=no
 OCAML_GTE_4_08_0=no
 case $(ocamlopt -version) in
-    4.05.[0-9]|4.05.[0-9]+*)
-        OCAML_EXTRA_DEPS=build/ocaml/byterun/caml/version.h
-        echo '#define OCAML_OS_TYPE "freestanding"' >> config/s.h
-        echo '#define INT64_LITERAL(s) s ## LL' >> config/m.${BUILD_ARCH}.h
-        # Use __ANDROID__ here to disable the AFL code, otherwise we'd have to
-        # add many more stubs to ocaml-freestanding.
-        echo 'afl.o: CFLAGS+=-D__ANDROID__' >> config/Makefile.${BUILD_OS}.${BUILD_ARCH}
-        ;;
     4.06.[0-9]|4.06.[0-9]+*)
-        OCAML_GTE_4_06_0=yes
         OCAML_EXTRA_DEPS=build/ocaml/byterun/caml/version.h
         echo '#define OCAML_OS_TYPE "freestanding"' >> config/s.h
         echo '#define INT64_LITERAL(s) s ## LL' >> config/m.${BUILD_ARCH}.h
         echo 'SYSTEM=freestanding' >> config/Makefile.${BUILD_OS}.${BUILD_ARCH}
         ;;
     4.07.[0-9]|4.07.[0-9]+*)
-        OCAML_GTE_4_06_0=yes
         OCAML_GTE_4_07_0=yes
         OCAML_EXTRA_DEPS=build/ocaml/byterun/caml/version.h
         echo '#define OCAML_OS_TYPE "freestanding"' >> config/s.h
@@ -65,7 +54,6 @@ case $(ocamlopt -version) in
         echo 'SYSTEM=freestanding' >> config/Makefile.${BUILD_OS}.${BUILD_ARCH}
         ;;
     4.08.[0-9]|4.08.[0-9]+*)
-        OCAML_GTE_4_06_0=yes
         OCAML_GTE_4_07_0=yes
         OCAML_GTE_4_08_0=yes
         OCAML_EXTRA_DEPS=build/ocaml/runtime/caml/version.h
@@ -74,7 +62,6 @@ case $(ocamlopt -version) in
         echo 'SYSTEM=freestanding' >> config/Makefile.${BUILD_OS}.${BUILD_ARCH}
         ;;
     4.09.[0-9]|4.09.[0-9]+*)
-        OCAML_GTE_4_06_0=yes
         OCAML_GTE_4_07_0=yes
         OCAML_GTE_4_08_0=yes
         OCAML_EXTRA_DEPS=build/ocaml/runtime/caml/version.h
@@ -106,7 +93,6 @@ NOLIBC_SYSDEP_OBJS=sysdeps_solo5.o
 PKG_CONFIG_DEPS=${PKG_CONFIG_DEPS}
 PKG_CONFIG_EXTRA_LIBS=${PKG_CONFIG_EXTRA_LIBS}
 OCAML_EXTRA_DEPS=${OCAML_EXTRA_DEPS}
-OCAML_GTE_4_06_0=${OCAML_GTE_4_06_0}
 OCAML_GTE_4_07_0=${OCAML_GTE_4_07_0}
 OCAML_GTE_4_08_0=${OCAML_GTE_4_08_0}
 EOM

--- a/opam
+++ b/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")
-  "ocaml" {>= "4.05.0" & < "4.10.0"}
+  "ocaml" {>= "4.06.0" & < "4.10.0"}
 ]
 substs: [
   "flags/cflags.tmp"


### PR DESCRIPTION
Mirage 3.7.0 requires OCaml >= 4.06.0, so drop support for 4.05.0 here.