### PR TITLE
Provide libdir, ld and ldflags into the distribution to be usable by dune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ flags/libs.tmp: flags/libs.tmp.in
 
 flags/libs.sexp: flags/libs.tmp Makeconf
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
-	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
+	    pkg-config $(PKG_CONFIG_DEPS) --static --libs >> $<
 	awk -v RS= -- '{ \
 	    sub("@@PKG_CONFIG_EXTRA_LIBS@@", "$(PKG_CONFIG_EXTRA_LIBS)", $$0); \
 	    print "(", $$0, ")" \

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ flags/ld: Makeconf
 flags/ldflags: Makeconf
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
 		pkg-config $(PKG_CONFIG_DEPS) --variable=ldflags >> $@
-#	sed -i "$@" -e 's/(\ )+/\n/g'
+	sed -i "$@" -E -e 's/[[:blank:]]+/\n/g'
 
 install: all
 	./install.sh

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ FREESTANDING_LIBS=build/openlibm/libopenlibm.a \
 		  build/nolibc/libnolibc.a
 endif
 
-all:	$(FREESTANDING_LIBS) ocaml-freestanding.pc flags/libs flags/cflags flags/ld flags/libdir flags/ldflags
+all:	$(FREESTANDING_LIBS) ocaml-freestanding.pc flags/libs.sexp flags/cflags.sexp flags/ld flags/libdir flags/ldflags
 
 Makeconf:
 	./configure.sh
@@ -113,7 +113,7 @@ ocaml-freestanding.pc: ocaml-freestanding.pc.in Makeconf
 flags/libs.tmp: flags/libs.tmp.in
 	opam config subst $@
 
-flags/libs: flags/libs.tmp Makeconf
+flags/libs.sexp: flags/libs.tmp Makeconf
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
 	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
 	awk -v RS= -- '{ \
@@ -124,7 +124,7 @@ flags/libs: flags/libs.tmp Makeconf
 flags/cflags.tmp: flags/cflags.tmp.in
 	opam config subst $@
 
-flags/cflags: flags/cflags.tmp Makeconf
+flags/cflags.sexp: flags/cflags.tmp Makeconf
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
 	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
 	awk -v RS= -- '{ \
@@ -145,7 +145,7 @@ flags/ld: Makeconf
 flags/ldflags: Makeconf
 	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
 		pkg-config $(PKG_CONFIG_DEPS) --variable=ldflags >> $@
-	sed -i "$@" -e 's/(\ )+/\n/g'
+#	sed -i "$@" -e 's/(\ )+/\n/g'
 
 install: all
 	./install.sh
@@ -155,5 +155,7 @@ uninstall:
 
 clean:
 	rm -rf build config Makeconf ocaml-freestanding.pc
-	rm -rf flags/libs flags/libs.tmp
-	rm -rf flags/cflags flags/cflags.tmp
+	rm -rf flags/libs.sexp flags/libs.tmp
+	rm -rf flags/cflags.sexp flags/cflags.tmp
+	rm -rf flags/ld
+	rm -rf flags/ldflags

--- a/flags/libs.tmp.in
+++ b/flags/libs.tmp.in
@@ -1,1 +1,1 @@
--L%{ocaml-freestanding:lib}% -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@
+-I %{ocaml-freestanding:lib}% -cclib -lasmrun -cclib -lnolibc -cclib -lopenlibm

--- a/flags/libs.tmp.in
+++ b/flags/libs.tmp.in
@@ -1,1 +1,1 @@
--I %{ocaml-freestanding:lib}% -cclib -lasmrun -cclib -lnolibc -cclib -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@
+-I %{ocaml-freestanding:lib}% -cclib -lasmrun -cclib -lnolibc -cclib -lopenlibm libmirage-solo5_bindings.a @@PKG_CONFIG_EXTRA_LIBS@@

--- a/flags/libs.tmp.in
+++ b/flags/libs.tmp.in
@@ -1,1 +1,1 @@
--I %{ocaml-freestanding:lib}% -cclib -lasmrun -cclib -lnolibc -cclib -lopenlibm
+-L%{ocaml-freestanding:lib}% -lasmrun -lnolibc -lopenlibm

--- a/flags/libs.tmp.in
+++ b/flags/libs.tmp.in
@@ -1,1 +1,1 @@
--L%{ocaml-freestanding:lib}% -lasmrun -lnolibc -lopenlibm
+-I %{ocaml-freestanding:lib}% -cclib -lasmrun -cclib -lnolibc -cclib -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@

--- a/install.sh
+++ b/install.sh
@@ -64,8 +64,8 @@ touch ${DESTLIB}/META
 # pkg-config
 mkdir -p ${prefix}/lib/pkgconfig
 cp ocaml-freestanding.pc ${prefix}/lib/pkgconfig/ocaml-freestanding.pc
-cp flags/cflags ${DESTLIB}
-cp flags/libs ${DESTLIB}
+cp flags/cflags.sexp ${DESTLIB}
+cp flags/libs.sexp ${DESTLIB}
 cp flags/libdir ${DESTLIB}
 cp flags/ld ${DESTLIB}
 cp flags/ldflags ${DESTLIB}

--- a/install.sh
+++ b/install.sh
@@ -66,3 +66,6 @@ mkdir -p ${prefix}/lib/pkgconfig
 cp ocaml-freestanding.pc ${prefix}/lib/pkgconfig/ocaml-freestanding.pc
 cp flags/cflags ${DESTLIB}
 cp flags/libs ${DESTLIB}
+cp flags/libdir ${DESTLIB}
+cp flags/ld ${DESTLIB}
+cp flags/ldflags ${DESTLIB}


### PR DESCRIPTION
Some information are missed (about #50). This PR add some others file to be usable by `dune` and compile/link correctly unikernels. Into details, `dune` with or without `duniverse` is able to load some information available from files.

In your case, `dune` can loads files located into `$(opam config var lib)/ocaml-freestanding/*` (with expansion of `%{lib:ocaml-freestanding:*}`). Currently, only `cflags` and `libs` are provided. This PR adds `ld`, `libdir` and `ldflags`.