### PR TITLE
Provide byte-swapping functions in endian.h, pass -D__ocaml_freestanding__ via CFLAGS

### DIFF
--- a/flags/cflags.tmp.in
+++ b/flags/cflags.tmp.in
@@ -1,1 +1,1 @@
--D__freestanding__ -I%{prefix}%/include/ocaml-freestanding
+-D__ocaml_freestanding__ -I%{prefix}%/include/ocaml-freestanding

--- a/flags/cflags.tmp.in
+++ b/flags/cflags.tmp.in
@@ -1,1 +1,1 @@
--D__ocaml_freestanding__ -I%{prefix}%/include/ocaml-freestanding
+-U__linux__ -U__linux -Ulinux -U__gnu_linux__ -U__FreeBSD__ -U__OpenBSD__ -D__ocaml_freestanding__ -I%{prefix}%/include/ocaml-freestanding

--- a/flags/cflags.tmp.in
+++ b/flags/cflags.tmp.in
@@ -1,1 +1,1 @@
--I%{prefix}%/include/ocaml-freestanding
+-D__freestanding__ -I%{prefix}%/include/ocaml-freestanding

--- a/nolibc/include/endian.h
+++ b/nolibc/include/endian.h
@@ -9,4 +9,57 @@
 #error Unsupported architecture
 #endif
 
+static __inline uint16_t __bswap16(uint16_t __x)
+{
+  return __x<<8 | __x>>8;
+}
+
+static __inline uint32_t __bswap32(uint32_t __x)
+{
+  return __x>>24 | (__x>>8&0xff00) | (__x<<8&0xff0000) | __x<<24;
+}
+
+static __inline uint64_t __bswap64(uint64_t __x)
+{
+  return (__bswap32(__x)+0ULL)<<32 | __bswap32(__x>>32);
+}
+
+#define bswap16(x) __bswap16(x)
+#define bswap32(x) __bswap32(x)
+#define bswap64(x) __bswap64(x)
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+
+#define htobe16(x) __bswap16(x)
+#define htobe32(x) __bswap32(x)
+#define htobe64(x) __bswap64(x)
+#define htole16(x) (uint16_t)(x)
+#define htole32(x) (uint32_t)(x)
+#define htole64(x) (uint64_t)(x)
+
+#define be16toh(x) __bswap16(x)
+#define be32toh(x) __bswap32(x)
+#define be64toh(x) __bswap64(x)
+#define le16toh(x) (uint16_t)(x)
+#define le32toh(x) (uint32_t)(x)
+#define le64toh(x) (uint64_t)(x)
+
+#else /* BYTE_ORDER != __LITTLE_ENDIAN */
+
+#define htobe16(x) (uint16_t)(x)
+#define htobe32(x) (uint32_t)(x)
+#define htobe64(x) (uint64_t)(x)
+#define htole16(x) __bswap16(x)
+#define htole32(x) __bswap32(x)
+#define htole64(x) __bswap64(x)
+
+#define be16toh(x) (uint16_t)(x)
+#define be32toh(x) (uint32_t)(x)
+#define be64toh(x) (uint64_t)(x)
+#define le16toh(x) __bswap16(x)
+#define le32toh(x) __bswap32(x)
+#define le64toh(x) __bswap64(x)
+
+#endif /* BYTE_ORDER == _LITTLE_ENDIAN */
+
 #endif

--- a/nolibc/include/endian.h
+++ b/nolibc/include/endian.h
@@ -1,45 +1,30 @@
 #ifndef _ENDIAN_H
 #define _ENDIAN_H
 
-#define __LITTLE_ENDIAN 1234
-#define __BIG_ENDIAN 4321
+#define LITTLE_ENDIAN 1234
+#define BIG_ENDIAN 4321
 #if defined(__x86_64__) || defined(__aarch64__)
-#define __BYTE_ORDER __LITTLE_ENDIAN
+#define BYTE_ORDER LITTLE_ENDIAN
 #else
 #error Unsupported architecture
 #endif
 
-static __inline uint16_t __bswap16(uint16_t __x)
-{
-  return __x<<8 | __x>>8;
-}
+#define bswap16(x) __builtin_bswap16(x)
+#define bswap32(x) __builtin_bswap32(x)
+#define bswap64(x) __builtin_bswap64(x)
 
-static __inline uint32_t __bswap32(uint32_t __x)
-{
-  return __x>>24 | (__x>>8&0xff00) | (__x<<8&0xff0000) | __x<<24;
-}
+#if BYTE_ORDER == LITTLE_ENDIAN
 
-static __inline uint64_t __bswap64(uint64_t __x)
-{
-  return (__bswap32(__x)+0ULL)<<32 | __bswap32(__x>>32);
-}
-
-#define bswap16(x) __bswap16(x)
-#define bswap32(x) __bswap32(x)
-#define bswap64(x) __bswap64(x)
-
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-
-#define htobe16(x) __bswap16(x)
-#define htobe32(x) __bswap32(x)
-#define htobe64(x) __bswap64(x)
+#define htobe16(x) bswap16(x)
+#define htobe32(x) bswap32(x)
+#define htobe64(x) bswap64(x)
 #define htole16(x) (uint16_t)(x)
 #define htole32(x) (uint32_t)(x)
 #define htole64(x) (uint64_t)(x)
 
-#define be16toh(x) __bswap16(x)
-#define be32toh(x) __bswap32(x)
-#define be64toh(x) __bswap64(x)
+#define be16toh(x) bswap16(x)
+#define be32toh(x) bswap32(x)
+#define be64toh(x) bswap64(x)
 #define le16toh(x) (uint16_t)(x)
 #define le32toh(x) (uint32_t)(x)
 #define le64toh(x) (uint64_t)(x)
@@ -49,16 +34,16 @@ static __inline uint64_t __bswap64(uint64_t __x)
 #define htobe16(x) (uint16_t)(x)
 #define htobe32(x) (uint32_t)(x)
 #define htobe64(x) (uint64_t)(x)
-#define htole16(x) __bswap16(x)
-#define htole32(x) __bswap32(x)
-#define htole64(x) __bswap64(x)
+#define htole16(x) bswap16(x)
+#define htole32(x) bswap32(x)
+#define htole64(x) bswap64(x)
 
 #define be16toh(x) (uint16_t)(x)
 #define be32toh(x) (uint32_t)(x)
 #define be64toh(x) (uint64_t)(x)
-#define le16toh(x) __bswap16(x)
-#define le32toh(x) __bswap32(x)
-#define le64toh(x) __bswap64(x)
+#define le16toh(x) bswap16(x)
+#define le32toh(x) bswap32(x)
+#define le64toh(x) bswap64(x)
 
 #endif /* BYTE_ORDER == _LITTLE_ENDIAN */
 

--- a/nolibc/include/endian.h
+++ b/nolibc/include/endian.h
@@ -1,4 +1,10 @@
+/* Solo5 used to copy <sys/endian.h> on BSD systems into the std include path.
+   To avoid multiple definitions of the same symbol, this header file is
+   guarded by both _SYS_ENDIAN_H and _ENDIAN_H. */
+
+#ifndef _SYS_ENDIAN_H
 #ifndef _ENDIAN_H
+#define _SYS_ENDIAN_H
 #define _ENDIAN_H
 
 #define LITTLE_ENDIAN 1234
@@ -47,4 +53,5 @@
 
 #endif /* BYTE_ORDER == _LITTLE_ENDIAN */
 
-#endif
+#endif /* _ENDIAN_H */
+#endif /* _SYS_ENDIAN_H */

--- a/ocaml-freestanding.pc.in
+++ b/ocaml-freestanding.pc.in
@@ -7,6 +7,6 @@ Name: ocaml-freestanding
 Version: 1.0.0
 URL: https://github.com/mirage/ocaml-freestanding/
 Description: Freestanding OCaml runtime
-Cflags: -I${includedir}
+Cflags: -D__freestanding__ -I${includedir}
 Libs: -L${libdir} -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@
 Requires: @@PKG_CONFIG_DEPS@@

--- a/ocaml-freestanding.pc.in
+++ b/ocaml-freestanding.pc.in
@@ -7,6 +7,6 @@ Name: ocaml-freestanding
 Version: 1.0.0
 URL: https://github.com/mirage/ocaml-freestanding/
 Description: Freestanding OCaml runtime
-Cflags: -D__ocaml_freestanding__ -I${includedir}
+Cflags: -U__linux__ -U__linux -Ulinux -U__gnu_linux__ -U__FreeBSD__ -U__OpenBSD__ -D__ocaml_freestanding__ -I${includedir}
 Libs: -L${libdir} -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@
 Requires: @@PKG_CONFIG_DEPS@@

--- a/ocaml-freestanding.pc.in
+++ b/ocaml-freestanding.pc.in
@@ -7,6 +7,6 @@ Name: ocaml-freestanding
 Version: 1.0.0
 URL: https://github.com/mirage/ocaml-freestanding/
 Description: Freestanding OCaml runtime
-Cflags: -D__freestanding__ -I${includedir}
+Cflags: -D__ocaml_freestanding__ -I${includedir}
 Libs: -L${libdir} -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@
 Requires: @@PKG_CONFIG_DEPS@@


### PR DESCRIPTION
the code of endian.h is taken from musl, and adapted to make clang's warnings go away.

in addition, `-D__freestanding__` is passed via CFLAGS, which allows other C code to use `#if defined(__freestanding__)` and conditionally do something.

An example use of both endian.h and the __freestanding__ is https://github.com/hannesm/mirage-crypto/commit/a66190dccf9c596c24dfc4a45a911ef9effafab7 (which compiles fine with this change and the corresponding solo5 PR).

I'm interested in your opinion, and am open for suggestions: given that BYTE_ORDER will always be LITTLE_ENDIAN, is it worth to keep the 12 lines of defines? should `-D __freestanding__` be renamed to something else?

This PR allows us to unify the copied headers of solo5 a bit more (see https://github.com/Solo5/solo5/pull/453), and has been requested in #71. It will as well help us to eventually resolve https://github.com/mirage/hacl/issues/30.