### PR TITLE
V2: Define __ocaml_freestanding__, fix the endian.h mess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ Makeconf:
 	./configure.sh
 
 TOP=$(abspath .)
-FREESTANDING_CFLAGS+=-isystem $(TOP)/nolibc/include
+FREESTANDING_CFLAGS+=-isystem $(TOP)/nolibc/include -include _freestanding/overrides.h
 
 build/openlibm/Makefile:
 	mkdir -p build/openlibm

--- a/flags/cflags.tmp.in
+++ b/flags/cflags.tmp.in
@@ -1,1 +1,1 @@
--I%{prefix}%/include/ocaml-freestanding
+-I%{prefix}%/include/ocaml-freestanding -include _freestanding/overrides.h

--- a/nolibc/include/_freestanding/byteorder.h
+++ b/nolibc/include/_freestanding/byteorder.h
@@ -1,0 +1,16 @@
+#ifndef __FREESTANDING_BYTEORDER_H
+#define __FREESTANDING_BYTEORDER_H
+
+#if !defined(__BYTE_ORDER__)
+#error C compiler does not define __BYTE_ORDER__
+#endif
+
+#if defined(BYTE_ORDER) || defined(LITTLE_ENDIAN) || defined(BIG_ENDIAN)
+#error BYTE_ORDER, LITTLE_ENDIAN or BIG_ENDIAN must not be defined here
+#endif
+
+#define BYTE_ORDER __BYTE_ORDER__
+#define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#define BIG_ENDIAN __ORDER_BIG_ENDIAN__
+
+#endif /* __FREESTANDING_BYTEORDER_H */

--- a/nolibc/include/_freestanding/overrides.h
+++ b/nolibc/include/_freestanding/overrides.h
@@ -1,0 +1,13 @@
+#ifndef __FREESTANDING_OVERRIDES_H
+#define __FREESTANDING_OVERRIDES_H
+
+#undef __FreeBSD__
+#undef __OpenBSD__
+#undef __gnu_linux__
+#undef __linux
+#undef __linux__
+#undef linux
+
+#define __ocaml_freestanding__
+
+#endif /* __FREESTANDING_OVERRIDES_H */

--- a/nolibc/include/endian.h
+++ b/nolibc/include/endian.h
@@ -1,12 +1,45 @@
 #ifndef _ENDIAN_H
 #define _ENDIAN_H
 
-#define __LITTLE_ENDIAN 1234
-#define __BIG_ENDIAN 4321
-#if defined(__x86_64__) || defined(__aarch64__)
-#define __BYTE_ORDER __LITTLE_ENDIAN
-#else
-#error Unsupported architecture
-#endif
+#include <_freestanding/byteorder.h>
+#include <stdint.h>
 
-#endif
+#define bswap16(x) __builtin_bswap16(x)
+#define bswap32(x) __builtin_bswap32(x)
+#define bswap64(x) __builtin_bswap64(x)
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+#define htobe16(x) bswap16(x)
+#define htobe32(x) bswap32(x)
+#define htobe64(x) bswap64(x)
+#define htole16(x) (uint16_t)(x)
+#define htole32(x) (uint32_t)(x)
+#define htole64(x) (uint64_t)(x)
+
+#define be16toh(x) bswap16(x)
+#define be32toh(x) bswap32(x)
+#define be64toh(x) bswap64(x)
+#define le16toh(x) (uint16_t)(x)
+#define le32toh(x) (uint32_t)(x)
+#define le64toh(x) (uint64_t)(x)
+
+#else /* BYTE_ORDER != LITTLE_ENDIAN */
+
+#define htobe16(x) (uint16_t)(x)
+#define htobe32(x) (uint32_t)(x)
+#define htobe64(x) (uint64_t)(x)
+#define htole16(x) bswap16(x)
+#define htole32(x) bswap32(x)
+#define htole64(x) bswap64(x)
+
+#define be16toh(x) (uint16_t)(x)
+#define be32toh(x) (uint32_t)(x)
+#define be64toh(x) (uint64_t)(x)
+#define le16toh(x) bswap16(x)
+#define le32toh(x) bswap32(x)
+#define le64toh(x) bswap64(x)
+
+#endif /* BYTE_ORDER == LITTLE_ENDIAN */
+
+#endif /* _ENDIAN_H */

--- a/nolibc/include/sys/param.h
+++ b/nolibc/include/sys/param.h
@@ -1,0 +1,6 @@
+#ifndef _SYS_PARAM_H
+#define _SYS_PARAM_H
+
+#include <_freestanding/byteorder.h>
+
+#endif /* _SYS_PARAM_H */

--- a/ocaml-freestanding.pc.in
+++ b/ocaml-freestanding.pc.in
@@ -7,6 +7,6 @@ Name: ocaml-freestanding
 Version: 1.0.0
 URL: https://github.com/mirage/ocaml-freestanding/
 Description: Freestanding OCaml runtime
-Cflags: -I${includedir}
+Cflags: -I${includedir} -include _freestanding/overrides.h
 Libs: -L${libdir} -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@
 Requires: @@PKG_CONFIG_DEPS@@


### PR DESCRIPTION
This is a re-work of #73, containing the following changes:

* nolibc: Provide a sys/param.h with BYTE_ORDER (~~83fc2b4~~ 3226548)
* nolibc: Provide a full endian.h (~~3c251fe~~ 5055052)
* nolibc: Define `__ocaml_freestanding__`, add overrides.h (239263b)

See individual commits for details.

/cc mirage/hacl#30 mirage/mirage-crypto#54 Solo5/solo5#453 @hannesm 
