### PR TITLE
Build system cleanups, provide minimal <inttypes.h>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ flags/libs
 flags/libs.tmp
 nolibc/*.o
 nolibc/*.a
+nolibc/test-include/
 ocaml/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 Makeconf
-build/
-config/
 ocaml-freestanding.pc
 flags/cflags
 flags/cflags.tmp
 flags/libs
 flags/libs.tmp
+nolibc/*.o
+nolibc/*.a
+ocaml/

--- a/install.sh
+++ b/install.sh
@@ -9,19 +9,19 @@ DESTLIB=${prefix}/lib/ocaml-freestanding
 mkdir -p ${DESTINC} ${DESTLIB}
 
 # "nolibc"
-cp -r build/nolibc/include/* ${DESTINC}
-cp build/nolibc/libnolibc.a ${DESTLIB}
+cp -r nolibc/include/* ${DESTINC}
+cp nolibc/libnolibc.a ${DESTLIB}
 
 # Openlibm
-cp -r build/openlibm/include/*  ${DESTINC}
-cp build/openlibm/src/*h ${DESTINC}
-cp build/openlibm/libopenlibm.a ${DESTLIB}
+cp -r openlibm/include/*  ${DESTINC}
+cp openlibm/src/*h ${DESTINC}
+cp openlibm/libopenlibm.a ${DESTLIB}
 
 # Ocaml runtime
 CAML_DESTINC=${DESTINC}/caml
 mkdir -p ${CAML_DESTINC}
-cp build/ocaml/runtime/caml/* ${CAML_DESTINC}
-cp build/ocaml/runtime/libasmrun.a ${DESTLIB}/libasmrun.a
+cp ocaml/runtime/caml/* ${CAML_DESTINC}
+cp ocaml/runtime/libasmrun.a ${DESTLIB}/libasmrun.a
 
 # META: ocamlfind and other build utilities test for existance ${DESTLIB}/META
 # when figuring out whether a library is installed

--- a/nolibc/Makefile
+++ b/nolibc/Makefile
@@ -7,10 +7,10 @@ endif
 
 all: libnolibc.a
 
-.PHONY: all clean
+.PHONY: all test-headers clean
 
 clean:
-	$(RM) libnolibc.a *.o
+	$(RM) libnolibc.a *.o test-include/*.[co] test-include/sys/*.[co]
 
 CC=cc
 CFLAGS=-O2 -std=c99 -Wall -Wno-parentheses -Werror
@@ -26,5 +26,30 @@ OBJS=ctype.o \
 
 dtoa.o: CFLAGS+=-fno-strict-aliasing
 
-libnolibc.a: $(OBJS) $(SYSDEP_OBJS)
+libnolibc.a: $(OBJS) $(SYSDEP_OBJS) test-headers
 	$(AR) rcs $@ $(OBJS) $(SYSDEP_OBJS)
+
+# The following test ensures that each header file provided by nolibc is both
+# self-contained and compile-tested. Note that headers in include/_freestanding
+# are not intended to be included directly, thus are exempt from this check.
+
+HEADERS=$(wildcard include/*.h include/sys/*.h)
+
+# For each HEADER we want to test, produce test-include/HEADER.o.  Note that
+# HEADER will include subdirectories, if matched.
+TEST_H_OBJS=$(patsubst %.h,test-%.o,$(HEADERS))
+
+# For each HEADER we want to test, generate a C source file including only
+# that HEADER. As above, HEADER may include subdirectories.
+test-include/%.c: include/%.h | test-include test-include/sys
+	echo "#include \"../$<\"" >$@
+
+.PRECIOUS: test-include/%.c
+
+test-include:
+	mkdir $@
+
+test-include/sys:
+	mkdir $@
+
+test-headers: $(TEST_H_OBJS)

--- a/nolibc/Makefile
+++ b/nolibc/Makefile
@@ -5,6 +5,13 @@ ifeq ($(SYSDEP_OBJS),)
     $(error SYSDEP_OBJS not set)
 endif
 
+all: libnolibc.a
+
+.PHONY: all clean
+
+clean:
+	$(RM) libnolibc.a *.o
+
 CC=cc
 CFLAGS=-O2 -std=c99 -Wall -Wno-parentheses -Werror
 CFLAGS+=$(FREESTANDING_CFLAGS)
@@ -21,4 +28,3 @@ dtoa.o: CFLAGS+=-fno-strict-aliasing
 
 libnolibc.a: $(OBJS) $(SYSDEP_OBJS)
 	$(AR) rcs $@ $(OBJS) $(SYSDEP_OBJS)
-

--- a/nolibc/include/inttypes.h
+++ b/nolibc/include/inttypes.h
@@ -1,0 +1,122 @@
+#ifndef _INTTYPES_H
+#define _INTTYPES_H
+
+#include <stdint.h>
+
+#if !defined(UINTPTR_MAX) || !defined(UINT64_MAX)
+#error UINTPTR_MAX and UINT64_MAX must be defined here
+#endif
+
+#if UINTPTR_MAX == UINT64_MAX
+#define __PRI64  "l"
+#define __PRIPTR "l"
+#else
+#define __PRI64  "ll"
+#define __PRIPTR ""
+#endif
+
+#define PRId8  "d"
+#define PRId16 "d"
+#define PRId32 "d"
+#define PRId64 __PRI64 "d"
+
+#define PRIdLEAST8  "d"
+#define PRIdLEAST16 "d"
+#define PRIdLEAST32 "d"
+#define PRIdLEAST64 __PRI64 "d"
+
+#define PRIdFAST8  "d"
+#define PRIdFAST16 "d"
+#define PRIdFAST32 "d"
+#define PRIdFAST64 __PRI64 "d"
+
+#define PRIi8  "i"
+#define PRIi16 "i"
+#define PRIi32 "i"
+#define PRIi64 __PRI64 "i"
+
+#define PRIiLEAST8  "i"
+#define PRIiLEAST16 "i"
+#define PRIiLEAST32 "i"
+#define PRIiLEAST64 __PRI64 "i"
+
+#define PRIiFAST8  "i"
+#define PRIiFAST16 "i"
+#define PRIiFAST32 "i"
+#define PRIiFAST64 __PRI64 "i"
+
+#define PRIo8  "o"
+#define PRIo16 "o"
+#define PRIo32 "o"
+#define PRIo64 __PRI64 "o"
+
+#define PRIoLEAST8  "o"
+#define PRIoLEAST16 "o"
+#define PRIoLEAST32 "o"
+#define PRIoLEAST64 __PRI64 "o"
+
+#define PRIoFAST8  "o"
+#define PRIoFAST16 "o"
+#define PRIoFAST32 "o"
+#define PRIoFAST64 __PRI64 "o"
+
+#define PRIu8  "u"
+#define PRIu16 "u"
+#define PRIu32 "u"
+#define PRIu64 __PRI64 "u"
+
+#define PRIuLEAST8  "u"
+#define PRIuLEAST16 "u"
+#define PRIuLEAST32 "u"
+#define PRIuLEAST64 __PRI64 "u"
+
+#define PRIuFAST8  "u"
+#define PRIuFAST16 "u"
+#define PRIuFAST32 "u"
+#define PRIuFAST64 __PRI64 "u"
+
+#define PRIx8  "x"
+#define PRIx16 "x"
+#define PRIx32 "x"
+#define PRIx64 __PRI64 "x"
+
+#define PRIxLEAST8  "x"
+#define PRIxLEAST16 "x"
+#define PRIxLEAST32 "x"
+#define PRIxLEAST64 __PRI64 "x"
+
+#define PRIxFAST8  "x"
+#define PRIxFAST16 "x"
+#define PRIxFAST32 "x"
+#define PRIxFAST64 __PRI64 "x"
+
+#define PRIX8  "X"
+#define PRIX16 "X"
+#define PRIX32 "X"
+#define PRIX64 __PRI64 "X"
+
+#define PRIXLEAST8  "X"
+#define PRIXLEAST16 "X"
+#define PRIXLEAST32 "X"
+#define PRIXLEAST64 __PRI64 "X"
+
+#define PRIXFAST8  "X"
+#define PRIXFAST16 "X"
+#define PRIXFAST32 "X"
+#define PRIXFAST64 __PRI64 "X"
+
+#define PRIdMAX __PRI64 "d"
+#define PRIiMAX __PRI64 "i"
+#define PRIoMAX __PRI64 "o"
+#define PRIuMAX __PRI64 "u"
+#define PRIxMAX __PRI64 "x"
+#define PRIXMAX __PRI64 "X"
+
+#define PRIdPTR __PRIPTR "d"
+#define PRIiPTR __PRIPTR "i"
+#define PRIoPTR __PRIPTR "o"
+#define PRIuPTR __PRIPTR "u"
+#define PRIxPTR __PRIPTR "x"
+#define PRIXPTR __PRIPTR "X"
+
+#endif


### PR DESCRIPTION
The primary goal here is to provide a minimal <inttypes.h>, which fixes #60. The associated changes improve the build system, notably adding compile-testing of all public headers provided by nolibc.

See individual commits for details:

- Build system cleanup, remove build/ (a5b14dd)
- nolibc: Compile-test public headers at build time (7ca57b9)
- nolibc: Provide a minimal <inttypes.h> (38a35e1)

/cc @hannesm @emillon @dinosaure (you asked for/could use an inttypes.h) @samoht (build system changes)