### PR TITLE
nolibc: Implement assert()

### DIFF
--- a/nolibc/Makefile
+++ b/nolibc/Makefile
@@ -16,7 +16,8 @@ CC=cc
 CFLAGS=-O2 -std=c99 -Wall -Wno-parentheses -Werror
 CFLAGS+=$(FREESTANDING_CFLAGS)
 
-OBJS=ctype.o \
+OBJS=assert.o \
+     ctype.o \
      dtoa.o \
      memchr.o memcmp.o memcpy.o memmove.o memset.o \
      strcmp.o strlen.o strtol.o strchr.o strchrnul.o strncpy.o stpncpy.o \

--- a/nolibc/assert.c
+++ b/nolibc/assert.c
@@ -1,0 +1,24 @@
+#include <solo5.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * These functions deliberately do not call printf() or malloc() in order to
+ * abort as quickly as possible without triggering further errors.
+ */
+
+static void puts(const char *s)
+{
+    solo5_console_write(s, strlen(s));
+}
+
+void _assert_fail(const char *file, const char *line, const char *e)
+{
+    puts(file);
+    puts(":");
+    puts(line);
+    puts(": Assertion `");
+    puts(e);
+    puts("' failed\n");
+    abort();
+}

--- a/nolibc/include/assert.h
+++ b/nolibc/include/assert.h
@@ -1,6 +1,16 @@
 #ifndef _ASSERT_H
 #define _ASSERT_H
 
-#define assert(x) (void)0
+extern void _assert_fail(const char *, const char *, const char *)
+    __attribute__((noreturn));
+
+#define _ASSERT_STR_EXPAND(y) #y
+#define _ASSERT_STR(x)        _ASSERT_STR_EXPAND(x)
+
+#define assert(e)                                              \
+    do {                                                       \
+        if (!(e))                                              \
+            _assert_fail(__FILE__, _ASSERT_STR(__LINE__), #e); \
+    } while (0)
 
 #endif


### PR DESCRIPTION
While working on the new Xen strack, I found that nolibc's <assert.h> was defining only a stub for assert(). Replace with a proper
implementation.