### PR TITLE
Travis, Cirrus CI: Update for OCaml 4.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,30 +13,35 @@ env:
     - DISTRO=alpine
 jobs:
   include:
+    # Build using the latest OCaml release on most common targets and architectures.
+    - name: OCaml 4.11, Solo5/hvt (amd64)
+      arch: amd64
+      env: OCAML_VERSION=4.11 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
+    - name: OCaml 4.11, Solo5/hvt, system switch (amd64)
+      arch: amd64
+      env: OCAML_VERSION=4.11 INSTALL_LOCAL=1 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
+    - name: OCaml 4.11, Solo5/spt (amd64)
+      arch: amd64
+      env: OCAML_VERSION=4.11 EXTRA_DEPS="solo5-bindings-spt" EXTRA_ENV="MIRAGE_TEST_MODE=spt"
+    - name: OCaml 4.11, Solo5/virtio (amd64)
+      arch: amd64
+      env: OCAML_VERSION=4.11 EXTRA_DEPS="solo5-bindings-virtio" EXTRA_ENV="MIRAGE_TEST_MODE=virtio"
+    - name: OCaml 4.11, Solo5/muen (amd64)
+      arch: amd64
+      env: OCAML_VERSION=4.11 EXTRA_DEPS="solo5-bindings-muen" EXTRA_ENV="MIRAGE_TEST_MODE=muen"
+    - name: OCaml 4.11, Solo5/hvt (arm64)
+      arch: arm64
+      env: OCAML_VERSION=4.11 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
+    - name: OCaml 4.11, Solo5/spt (arm64)
+      arch: arm64
+      env: OCAML_VERSION=4.11 EXTRA_DEPS="solo5-bindings-spt" EXTRA_ENV="MIRAGE_TEST_MODE=spt"
+    # Build previous but still supported OCaml releases only on amd64 and hvt.
     - name: OCaml 4.10, Solo5/hvt (amd64)
       arch: amd64
-      env: OCAML_VERSION=4.10.0 EXTRA_DEPS="solo5-bindings-hvt"
+      env: OCAML_VERSION=4.10 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
     - name: OCaml 4.09, Solo5/hvt (amd64)
       arch: amd64
       env: OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
-    - name: OCaml 4.09, Solo5/hvt, system switch (amd64)
-      arch: amd64
-      env: OCAML_VERSION=4.09 INSTALL_LOCAL=1 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
-    - name: OCaml 4.09, Solo5/spt (amd64)
-      arch: amd64
-      env: OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt" EXTRA_ENV="MIRAGE_TEST_MODE=spt"
-    - name: OCaml 4.09, Solo5/virtio (amd64)
-      arch: amd64
-      env: OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-virtio" EXTRA_ENV="MIRAGE_TEST_MODE=virtio"
-    - name: OCaml 4.09, Solo5/muen (amd64)
-      arch: amd64
-      env: OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-muen" EXTRA_ENV="MIRAGE_TEST_MODE=muen"
-    - name: OCaml 4.09, Solo5/hvt (arm64)
-      arch: arm64
-      env: OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"
-    - name: OCaml 4.09, Solo5/spt (arm64)
-      arch: arm64
-      env: OCAML_VERSION=4.09 EXTRA_DEPS="solo5-bindings-spt" EXTRA_ENV="MIRAGE_TEST_MODE=spt"
     - name: OCaml 4.08, Solo5/hvt (amd64)
       arch: amd64
       env: OCAML_VERSION=4.08 EXTRA_DEPS="solo5-bindings-hvt" EXTRA_ENV="MIRAGE_TEST_MODE=hvt"


### PR DESCRIPTION
For Travis, test common archs and targets for the latest OCaml release, and only amd64/hvt for previous releases.

/cc @kit-ty-kate 