### PR TITLE
Various fixes and improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean install
+.PHONY: all clean install uninstall distclean
 
 include Makeconf
 
@@ -97,7 +97,7 @@ uninstall:
 	./uninstall.sh
 
 clean:
-	$(MAKE) -C ocaml/runtime clean
+	-$(MAKE) -C ocaml/runtime clean
 	$(MAKE) -C openlibm clean
 	$(MAKE) -C nolibc \
 	    "FREESTANDING_CFLAGS=$(NOLIBC_CFLAGS)" \
@@ -106,3 +106,6 @@ clean:
 	$(RM) Makeconf ocaml-freestanding.pc
 	$(RM) flags/libs flags/libs.tmp
 	$(RM) flags/cflags flags/cflags.tmp
+
+distclean: clean
+	$(RM) -r ocaml/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ocaml-freestanding` during the link step.
 
 ## Supported compiler versions
 
-Tested against OCaml 4.08.0 through 4.10.0. Other versions may require
+Tested against OCaml 4.08.0 through 4.11.1. Other versions may require
 changing `configure.sh`.
 
 ## Porting to a different (uni)kernel base layer

--- a/nolibc/assert.c
+++ b/nolibc/assert.c
@@ -1,6 +1,6 @@
-#include <solo5.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 /*
  * These functions deliberately do not call printf() or malloc() in order to
@@ -9,7 +9,7 @@
 
 static void puts(const char *s)
 {
-    solo5_console_write(s, strlen(s));
+    (void)write(2, s, strlen(s));
 }
 
 void _assert_fail(const char *file, const char *line, const char *e)

--- a/nolibc/dlmalloc.i
+++ b/nolibc/dlmalloc.i
@@ -3166,12 +3166,16 @@ static int init_mparams(void) {
       }
       else
 #endif /* USE_DEV_RANDOM */
+#ifdef __ocaml_freestanding__
+      magic = (size_t)(solo5_clock_monotonic() ^ 0x55555555UL);
+#else /* __ocaml_freestanding__ */
 #ifdef WIN32
       magic = (size_t)(GetTickCount() ^ (size_t)0x55555555U);
 #elif defined(LACKS_TIME_H)
       magic = (size_t)&magic ^ (size_t)0x55555555U;
 #else
       magic = (size_t)(time(0) ^ (size_t)0x55555555U);
+#endif
 #endif
       magic |= (size_t)8U;    /* ensure nonzero */
       magic &= ~(size_t)7U;   /* improve chances of fault for bad values */

--- a/nolibc/dlmalloc.i
+++ b/nolibc/dlmalloc.i
@@ -1444,8 +1444,7 @@ DLMALLOC_EXPORT int mspace_mallopt(int, int);
 #undef assert
 #define assert(x) if(!(x)) ABORT
 #else /* ABORT_ON_ASSERT_FAILURE */
-/* Not present on Solo5 */
-/* #include <assert.h> */
+#include <assert.h>
 #endif /* ABORT_ON_ASSERT_FAILURE */
 #else  /* DEBUG */
 #ifndef assert

--- a/nolibc/sysdeps_solo5.c
+++ b/nolibc/sysdeps_solo5.c
@@ -124,17 +124,13 @@ void *sbrk(intptr_t increment)
  */
 
 /*
- * DEBUG not defined and assertions compiled out corresponds to the default
- * recommended configuration (see documentation below). If you need to debug
- * dlmalloc on Solo5 then define DEBUG to `1' here.
+ * DEBUG not defined and assertions enabled corresponds to the recommended
+ * configuration as our assert() does not call malloc().  (see documentation in
+ * dlmalloc.i). If you need to debug dlmalloc on Solo5 then define DEBUG to `1'
+ * here.
  */
-#if defined(DEBUG) && (DEBUG)
+#include <assert.h>
 #define ABORT_ON_ASSERT_FAILURE 0
-#else
-#undef assert
-#define assert(x)
-#define STRUCT_MALLINFO_DECLARED 1
-#endif
 
 #undef WIN32
 #define HAVE_MMAP 0
@@ -150,6 +146,7 @@ void *sbrk(intptr_t increment)
 #define LACKS_TIME_H
 #define MALLOC_FAILURE_ACTION
 #define USE_LOCKS 0
+#define STRUCT_MALLINFO_DECLARED 1
 
 /* disable null-pointer-arithmetic warning on clang */
 #if defined(__clang__) && __clang_major__ >= 6

--- a/nolibc/sysdeps_solo5.c
+++ b/nolibc/sysdeps_solo5.c
@@ -147,6 +147,7 @@ void *sbrk(intptr_t increment)
 #define MALLOC_FAILURE_ACTION
 #define USE_LOCKS 0
 #define STRUCT_MALLINFO_DECLARED 1
+#define FOOTERS 1
 
 /* disable null-pointer-arithmetic warning on clang */
 #if defined(__clang__) && __clang_major__ >= 6

--- a/opam
+++ b/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")
-  "ocaml" {>= "4.08.0" & < "4.11.0"}
+  "ocaml" {>= "4.08.0" & < "4.12.0"}
 ]
 substs: [
   "flags/cflags.tmp"


### PR DESCRIPTION
- nolibc: assert(): Use write(2, ...) rather than solo5_console_write().
- nolibc: dlmalloc: Always enable assertions.
- Makefile: add distclean.
- nolibc: dlmalloc: Enable FOOTERS, initialise magic using monotonic clock. (Fixes #48).
- opam: Mark compatible with OCaml 4.11.x.

