### PR TITLE
cirrus: update tested compiler versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,9 @@ freebsd_task:
   env:
     matrix:
       - OCAML_VERSION: 4.08.1
-      - OCAML_VERSION: 4.09.0
-      - OCAML_VERSION: 4.10.0
+      - OCAML_VERSION: 4.09.1
+      - OCAML_VERSION: 4.10.1
+      - OCAML_VERSION: 4.11.1
   pkg_install_script: pkg install -y ocaml-opam gmp gmake pkgconf bash
   ocaml_script: opam init -a --comp=$OCAML_VERSION
   solo5_script: eval `opam env` && opam install solo5-bindings-hvt


### PR DESCRIPTION
Dor each supported compiler, test the most recent release on FreeBSD. Adds
testing with OCaml 4.11.1.

This was partially part of #83, which fails due to Travis + OCaml CI scripts still not supporting OCaml 4.11. See https://discuss.ocaml.org/t/removing-fat-compiler-images-on-hub-docker-com-r-ocaml-opam2/ and https://github.com/ocaml/ocaml-ci-scripts/pull/347 for further information and potential workarounds.