### PR TITLE
Remove cflags & libs flags, installing pkg-config data as s-expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
 Makeconf
 ocaml-freestanding.pc
-flags/cflags
-flags/cflags.tmp
-flags/libs
-flags/libs.tmp
 nolibc/*.o
 nolibc/*.a
 nolibc/test-include/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ FREESTANDING_LIBS=openlibm/libopenlibm.a \
 		  ocaml/runtime/libasmrun.a \
 		  nolibc/libnolibc.a
 
-all:	$(FREESTANDING_LIBS) ocaml-freestanding.pc flags/libs flags/cflags
+all:	$(FREESTANDING_LIBS) ocaml-freestanding.pc
 
 Makeconf:
 	./configure.sh
@@ -69,27 +69,6 @@ ocaml-freestanding.pc: ocaml-freestanding.pc.in Makeconf
 	    -e 's!@@PKG_CONFIG_EXTRA_LIBS@@!$(PKG_CONFIG_EXTRA_LIBS)!' \
 	    ocaml-freestanding.pc.in > $@
 
-flags/libs.tmp: flags/libs.tmp.in
-	opam config subst $@
-
-flags/libs: flags/libs.tmp Makeconf
-	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
-	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
-	awk -v RS= -- '{ \
-	    sub("@@PKG_CONFIG_EXTRA_LIBS@@", "$(PKG_CONFIG_EXTRA_LIBS)", $$0); \
-	    print "(", $$0, ")" \
-	    }' $< >$@
-
-flags/cflags.tmp: flags/cflags.tmp.in
-	opam config subst $@
-
-flags/cflags: flags/cflags.tmp Makeconf
-	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
-	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
-	awk -v RS= -- '{ \
-	    print "(", $$0, ")" \
-	    }' $< >$@
-
 install: all
 	./install.sh
 
@@ -104,8 +83,6 @@ clean:
 	    "SYSDEP_OBJS=$(NOLIBC_SYSDEP_OBJS)" \
 	    clean
 	$(RM) Makeconf ocaml-freestanding.pc
-	$(RM) flags/libs flags/libs.tmp
-	$(RM) flags/cflags flags/cflags.tmp
 
 distclean: clean
 	$(RM) -r ocaml/

--- a/flags/cflags.tmp.in
+++ b/flags/cflags.tmp.in
@@ -1,1 +1,0 @@
--I%{prefix}%/include/ocaml-freestanding -include _freestanding/overrides.h

--- a/flags/libs.tmp.in
+++ b/flags/libs.tmp.in
@@ -1,1 +1,0 @@
--L%{ocaml-freestanding:lib}% -lasmrun -lnolibc -lopenlibm @@PKG_CONFIG_EXTRA_LIBS@@

--- a/install.sh
+++ b/install.sh
@@ -30,5 +30,3 @@ touch ${DESTLIB}/META
 # pkg-config
 mkdir -p ${prefix}/lib/pkgconfig
 cp ocaml-freestanding.pc ${prefix}/lib/pkgconfig/ocaml-freestanding.pc
-cp flags/cflags ${DESTLIB}
-cp flags/libs ${DESTLIB}

--- a/opam
+++ b/opam
@@ -15,10 +15,6 @@ depends: [
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")
   "ocaml" {>= "4.08.0" & < "4.12.0"}
 ]
-substs: [
-  "flags/cflags.tmp"
-  "flags/libs.tmp"
-]
 conflicts: [
   "sexplib" {= "v0.9.0"}
   "solo5-kernel-ukvm"


### PR DESCRIPTION
These files were added in #50 (v0.4.3) when we planned to use this path to
compile MirageOS. Time has changed, and there is a different plan now, which
makes these superfluous.

In the light of #90 this here is a self-contained small PR.