### PR TITLE
Make build system more flexible to aid with NixOS packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 
 include Makeconf
 
+ifneq ($(shell command -v opam),)
+	# only set if opam is available and PKG_CONFIG_PATH isn't
+	# already set in the environment or on the command line
+	PKG_CONFIG_PATH ?= $(shell opam config var prefix)/lib/pkgconfig
+endif
+
 FREESTANDING_LIBS=openlibm/libopenlibm.a \
 		  ocaml/runtime/libasmrun.a \
 		  nolibc/libnolibc.a
@@ -73,8 +79,7 @@ flags/libs.tmp: flags/libs.tmp.in
 	opam config subst $@
 
 flags/libs: flags/libs.tmp Makeconf
-	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
-	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
+	pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
 	awk -v RS= -- '{ \
 	    sub("@@PKG_CONFIG_EXTRA_LIBS@@", "$(PKG_CONFIG_EXTRA_LIBS)", $$0); \
 	    print "(", $$0, ")" \
@@ -84,8 +89,7 @@ flags/cflags.tmp: flags/cflags.tmp.in
 	opam config subst $@
 
 flags/cflags: flags/cflags.tmp Makeconf
-	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
-	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
+	pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
 	awk -v RS= -- '{ \
 	    print "(", $$0, ")" \
 	    }' $< >$@

--- a/configure.sh
+++ b/configure.sh
@@ -11,13 +11,19 @@ if pkg_exists solo5-bindings-hvt solo5-bindings-spt solo5-bindings-virtio solo5-
     echo "ERROR: Only one of solo5-bindings-hvt, solo5-bindings-spt, solo5-bindings-virtio, solo5-bindings-muen, solo5-bindings-genode, solo5-bindings-xen can be installed." 1>&2
     exit 1
 fi
-PKG_CONFIG_DEPS=
-pkg_exists solo5-bindings-hvt && PKG_CONFIG_DEPS=solo5-bindings-hvt
-pkg_exists solo5-bindings-spt && PKG_CONFIG_DEPS=solo5-bindings-spt
-pkg_exists solo5-bindings-muen && PKG_CONFIG_DEPS=solo5-bindings-muen
-pkg_exists solo5-bindings-virtio && PKG_CONFIG_DEPS=solo5-bindings-virtio
-pkg_exists solo5-bindings-genode && PKG_CONFIG_DEPS=solo5-bindings-genode
-pkg_exists solo5-bindings-xen && PKG_CONFIG_DEPS=solo5-bindings-xen
+if [ -z "${PKG_CONFIG_DEPS}" ]; then
+    PKG_CONFIG_DEPS=
+    pkg_exists solo5-bindings-hvt && PKG_CONFIG_DEPS=solo5-bindings-hvt
+    pkg_exists solo5-bindings-spt && PKG_CONFIG_DEPS=solo5-bindings-spt
+    pkg_exists solo5-bindings-muen && PKG_CONFIG_DEPS=solo5-bindings-muen
+    pkg_exists solo5-bindings-virtio && PKG_CONFIG_DEPS=solo5-bindings-virtio
+    pkg_exists solo5-bindings-genode && PKG_CONFIG_DEPS=solo5-bindings-genode
+    pkg_exists solo5-bindings-xen && PKG_CONFIG_DEPS=solo5-bindings-xen
+else
+    pkg_exists "${PKG_CONFIG_DEPS}" \
+        || (echo "ERROR: ${PKG_CONFIG_DEPS} is not installed" 1>&2; exit 1) \
+        || exit 1
+fi
 if [ -z "${PKG_CONFIG_DEPS}" ]; then
     echo "ERROR: No supported Solo5 bindings package found." 1>&2
     echo "ERROR: solo5-bindings-hvt, solo5-bindings-spt, solo5-bindings-virtio, solo5-bindings-muen, solo5-bindings-genode or solo5-bindings-xen must be installed." 1>&2

--- a/configure.sh
+++ b/configure.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-export PKG_CONFIG_PATH=$(opam config var prefix)/lib/pkgconfig
+if command -v opam &> /dev/null; then
+    export PKG_CONFIG_PATH=$(opam config var prefix)/lib/pkgconfig
+fi
 pkg_exists() {
     pkg-config --exists "$@"
 }
@@ -21,7 +23,7 @@ if [ -z "${PKG_CONFIG_DEPS}" ]; then
     echo "ERROR: solo5-bindings-hvt, solo5-bindings-spt, solo5-bindings-virtio, solo5-bindings-muen, solo5-bindings-genode or solo5-bindings-xen must be installed." 1>&2
     exit 1
 fi
-ocamlfind query ocaml-src >/dev/null || exit 1
+[ -e "$(dirname "$0")/ocaml" ] || ocamlfind query ocaml-src >/dev/null || exit 1
 
 FREESTANDING_CFLAGS="$(pkg-config --cflags ${PKG_CONFIG_DEPS})"
 BUILD_ARCH="$(uname -m)"


### PR DESCRIPTION
This PR contains two patches for the build system I wrote while giving packaging `ocaml-freestanding` for NixOS a shot. I wanted to make the following things possible:

* Building without the `ocaml-src` package by alternatively extracting the ocaml source archive to `./ocaml` manually
* Building without `opam`
* Overriding the auto detection mechanism which selects the solo5 binding to use

The commit messages have more details on the reasoning.

I tried to preserve the old default behavior, but can't say for sure I haven't broken anything. Someone with a more “normal” setup testing this would be appreciated!

I don't need a merge desparately, I can also vendor these patches in `nixpkgs`. If you are switching to `dune` anyways, it not be worth it to mess with the build system.