### PR TITLE
4.13 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ ocaml/Makefile.config: ocaml/Makefile
 	    CPPFLAGS="$(OCAML_CFLAGS)" \
 	    ./configure --host=$(BUILD_ARCH)-unknown-none
 	echo "ARCH=$(OCAML_BUILD_ARCH)" >> ocaml/Makefile.config
+	echo 'SAK_CC=cc' >> ocaml/Makefile.config
+	echo 'SAK_CFLAGS=$(OC_CFLAGS) $(OC_CPPFLAGS)' >> ocaml/Makefile.config
+	echo 'SAK_LINK=$(SAK_CC) $(SAK_CFLAGS) $(OUTPUTEXE)$(1) $(2)' >> ocaml/Makefile.config
 	echo '#define HAS_GETTIMEOFDAY' >> ocaml/runtime/caml/s.h
 	echo '#define HAS_SECURE_GETENV' >> ocaml/runtime/caml/s.h
 	echo '#define HAS_TIMES' >> ocaml/runtime/caml/s.h

--- a/opam
+++ b/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")
-  "ocaml" {>= "4.08.0" & < "4.13.0"}
+  "ocaml" {>= "4.08.0" & < "4.14.0"}
 ]
 substs: [
   "flags/cflags.tmp"


### PR DESCRIPTION
A change made to OCaml before 4.13 was branched slowed down the Windows build, but the fix (although ready for review) was deferred until during the beta cycle. The story of the fix is long and not entirely relevant, but the solution is that there is now a one-file C program in `runtime/` which forms part of the _build system_ and so has to be built with a host ("build") C compiler. There should be an elegant solution to this in future when the OCaml tree itself natively supports cross-compilation, but in the meantime we're proposing inserting three variable hooks which ocaml-freestanding (and other cross-compiling setups) can use.

This can be tested with

```
opam pin add ocaml-src git+https://github.com/dra27/ocaml.git#freestanding-sak-4.13 -yn
opam pin add ocaml-freestanding git+https://github.com/dra27/ocaml-freestanding.git#4.13-sak -y
```

cc @kit-ty-kate