### PR TITLE
A slightly different version of #102

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,6 @@ ocaml/Makefile:
 #   compiler.
 # - ARCH must be overridden manually in Makefile.config due to the use of
 #   hardcoded combinations in the OCaml configure.
-# - HAS_XXX must be defined manually since our invocation of configure cannot
-#   link against nolibc (which would need to produce complete Solo5 binaries).
 # - We override OCAML_OS_TYPE since configure just hardcodes it to "Unix".
 OCAML_CFLAGS=$(FREESTANDING_CFLAGS) -I$(TOP)/openlibm/include -I$(TOP)/openlibm/src
 OCAML_LDFLAGS=$(FREESTANDING_LDFLAGS) -L$(TOP)/openlibm -L$(TOP)/nolibc
@@ -53,8 +51,6 @@ ocaml/Makefile.config: ocaml/Makefile openlibm/libopenlibm.a nolibc/libnolibc.a
 	echo 'SAK_CC=cc' >> ocaml/Makefile.config
 	echo 'SAK_CFLAGS=$(OC_CFLAGS) $(OC_CPPFLAGS)' >> ocaml/Makefile.config
 	echo 'SAK_LINK=$(SAK_CC) $(SAK_CFLAGS) $(OUTPUTEXE)$(1) $(2)' >> ocaml/Makefile.config
-	echo '#define HAS_GETTIMEOFDAY' >> ocaml/runtime/caml/s.h
-	echo '#define HAS_SECURE_GETENV' >> ocaml/runtime/caml/s.h
 	echo '#define HAS_TIMES' >> ocaml/runtime/caml/s.h
 	echo '#undef OCAML_OS_TYPE' >> ocaml/runtime/caml/s.h
 	echo '#define OCAML_OS_TYPE "None"' >> ocaml/runtime/caml/s.h

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ openlibm/libopenlibm.a:
 
 ocaml/Makefile:
 	cp -r `ocamlfind query ocaml-src` ./ocaml
+	cd ocaml && ../patches/run.sh
 
 # OCaml >= 4.08.0 uses an autotools-based build system. In this case we
 # convince it to think it's using the Solo5 compiler as a cross compiler, and

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,13 @@ ocaml/Makefile:
 #   link against nolibc (which would need to produce complete Solo5 binaries).
 # - We override OCAML_OS_TYPE since configure just hardcodes it to "Unix".
 OCAML_CFLAGS=$(FREESTANDING_CFLAGS) -I$(TOP)/openlibm/include -I$(TOP)/openlibm/src
-OCAML_LDFLAGS=$(FREESTANDING_LDFLAGS) -L$(TOP)/openlibm/
+OCAML_LDFLAGS=$(FREESTANDING_LDFLAGS) -L$(TOP)/openlibm -L$(TOP)/nolibc
 
-ocaml/Makefile.config: ocaml/Makefile
+ocaml/Makefile.config: ocaml/Makefile openlibm/libopenlibm.a nolibc/libnolibc.a
 	cd ocaml && \
 	    CC="cc $(OCAML_CFLAGS) -nostdlib" \
 	    LDFLAGS="$(OCAML_LDFLAGS)" \
-	    LIBS="-lopenlibm" \
+	    LIBS="-lopenlibm -lnolibc" \
 	    AS="as" \
 	    ASPP="cc $(OCAML_CFLAGS) -c" \
 	    LD="ld" \

--- a/configure.sh
+++ b/configure.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export PKG_CONFIG_PATH=$(opam config var prefix)/lib/pkgconfig
+export PKG_CONFIG_PATH=$(opam var prefix)/lib/pkgconfig
 pkg_exists() {
     pkg-config --exists "$@"
 }

--- a/configure.sh
+++ b/configure.sh
@@ -24,6 +24,7 @@ fi
 ocamlfind query ocaml-src >/dev/null || exit 1
 
 FREESTANDING_CFLAGS="$(pkg-config --cflags ${PKG_CONFIG_DEPS})"
+FREESTANDING_LDFLAGS="$(pkg-config --variable=ldflags ${PKG_CONFIG_DEPS})"
 BUILD_ARCH="$(uname -m)"
 BUILD_OS="$(uname -s)"
 OCAML_BUILD_ARCH=
@@ -51,6 +52,7 @@ fi
 
 cat <<EOM >Makeconf
 FREESTANDING_CFLAGS=${FREESTANDING_CFLAGS}
+FREESTANDING_LDFLAGS=${FREESTANDING_LDFLAGS}
 BUILD_ARCH=${BUILD_ARCH}
 BUILD_OS=${BUILD_OS}
 OCAML_BUILD_ARCH=${OCAML_BUILD_ARCH}

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 prefix=${1:-$PREFIX}
 if [ "$prefix" = "" ]; then
-    prefix=`opam config var prefix`
+    prefix=`opam var prefix`
 fi
 DESTINC=${prefix}/include/ocaml-freestanding
 DESTLIB=${prefix}/lib/ocaml-freestanding

--- a/nolibc/sysdeps_solo5.c
+++ b/nolibc/sysdeps_solo5.c
@@ -119,6 +119,12 @@ void *sbrk(intptr_t increment)
     return (void *)prev;
 }
 
+/* solo5_app_main as a weak symbol to allow linking executables without
+   mirage_solo5 / mirage_xen */
+int __attribute__((weak)) solo5_app_main (const struct solo5_start_info *info) {
+  return 0;
+}
+
 /*
  * dlmalloc configuration:
  */

--- a/patches/4.08.0/00-configure.patch
+++ b/patches/4.08.0/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 4e8ad00a5..9fe019864 100755
+--- a/configure
++++ b/configure
+@@ -12682,7 +12682,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.08.1/00-configure.patch
+++ b/patches/4.08.1/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 9a78a4554..8bef641f0 100755
+--- a/configure
++++ b/configure
+@@ -12694,7 +12694,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.09.0/00-configure.patch
+++ b/patches/4.09.0/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 85fb6842d..eb51479df 100755
+--- a/configure
++++ b/configure
+@@ -12664,7 +12664,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.09.1/00-configure.patch
+++ b/patches/4.09.1/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index d9cc166e0..e7c7c3a41 100755
+--- a/configure
++++ b/configure
+@@ -12689,7 +12689,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.10.0/00-configure.patch
+++ b/patches/4.10.0/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index b8f74728f..f79f55fd6 100755
+--- a/configure
++++ b/configure
+@@ -12790,7 +12790,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.10.1/00-configure.patch
+++ b/patches/4.10.1/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 2dbde09f1..bd1316d30 100755
+--- a/configure
++++ b/configure
+@@ -12790,7 +12790,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.10.2/00-configure.patch
+++ b/patches/4.10.2/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 7539fe0f1..86f891a87 100755
+--- a/configure
++++ b/configure
+@@ -12836,7 +12836,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.11.0/00-configure.patch
+++ b/patches/4.11.0/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index b6c44d22d..49711596c 100755
+--- a/configure
++++ b/configure
+@@ -12814,7 +12814,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.11.1/00-configure.patch
+++ b/patches/4.11.1/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 74657d2d9..93a5ce362 100755
+--- a/configure
++++ b/configure
+@@ -12814,7 +12814,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.11.2/00-configure.patch
+++ b/patches/4.11.2/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 50a7bb226..c81b8089b 100755
+--- a/configure
++++ b/configure
+@@ -12814,7 +12814,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.12.0/00-configure.patch
+++ b/patches/4.12.0/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 34330eab3..d7527d9cf 100755
+--- a/configure
++++ b/configure
+@@ -12984,7 +12984,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.12.1/00-configure.patch
+++ b/patches/4.12.1/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 81a77e3b6..9dc7663dc 100755
+--- a/configure
++++ b/configure
+@@ -12991,7 +12991,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.13.0/00-configure.patch
+++ b/patches/4.13.0/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 961232fc1..49382eed9 100755
+--- a/configure
++++ b/configure
+@@ -13369,7 +13369,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/4.13.1/00-configure.patch
+++ b/patches/4.13.1/00-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index bf3052be4..f42b4c4d4 100755
+--- a/configure
++++ b/configure
+@@ -13369,7 +13369,7 @@ return cos ();
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_lib_m_cos=yes
++  ac_cv_lib_m_cos=no
+ else
+   ac_cv_lib_m_cos=no
+ fi

--- a/patches/run.sh
+++ b/patches/run.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#to be executed from <TOP>/ocaml
+
+patch_dir="../patches/"$(ocaml -vnum)
+
+if [ -d $patch_dir ]; then
+    for x in $(ls $patch_dir); do
+        echo "applying patch $x";
+        patch -p1 < $patch_dir/$x
+    done
+else
+    echo "no patch directory found at $patch_dir (unsupported OCaml version?)";
+    exit 1
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,7 +2,7 @@
 
 prefix=$1
 if [ "$prefix" = "" ]; then
-  prefix=`opam config var prefix`
+  prefix=`opam var prefix`
 fi
 
 odir=$prefix/lib


### PR DESCRIPTION
This is a slightly different version of #102 which keeps `HAS_SECURE_GETENV` to be able to produce an unikernel without Unix syscalls (/cc @hannesm).